### PR TITLE
Add observer name field to observations (#133)

### DIFF
--- a/src/react-app/api/exports.ts
+++ b/src/react-app/api/exports.ts
@@ -15,6 +15,7 @@ export async function generateExcelFromObservations(
 
   // Define columns
   worksheet.columns = [
+    { header: "Observatør", key: "observerName", width: 20 },
     { header: "Lokalitet", key: "locationName", width: 20 },
     { header: "Latitude", key: "latitude", width: 12 },
     { header: "Longitude", key: "longitude", width: 12 },
@@ -42,11 +43,14 @@ export async function generateExcelFromObservations(
   // Add data rows
   observations.forEach((obs) => {
     worksheet.addRow({
+      observerName: obs.observerName || "",
       locationName: obs.locationName,
       latitude: obs.location.lat,
       longitude: obs.location.lng,
       uncertainty: obs.uncertaintyRadius,
-      startDate: obs.startDate ? new Date(obs.startDate).toLocaleString("no-NO") : "",
+      startDate: obs.startDate
+        ? new Date(obs.startDate).toLocaleString("no-NO")
+        : "",
       endDate: obs.endDate ? new Date(obs.endDate).toLocaleString("no-NO") : "",
       comment: obs.comment || "",
       lastExportedAt: obs.lastExportedAt

--- a/src/react-app/api/profiles.ts
+++ b/src/react-app/api/profiles.ts
@@ -1,0 +1,12 @@
+import { supabase } from "../lib/supabase.ts";
+import { Profile } from "../types/profile.ts";
+
+export async function fetchProfiles(): Promise<Profile[]> {
+  const { data, error } = await supabase
+    .from("profiles")
+    .select("id, email, display_name, updated_at")
+    .order("display_name", { ascending: true });
+
+  if (error) throw error;
+  return data ?? [];
+}

--- a/src/react-app/components/ObservationForm.tsx
+++ b/src/react-app/components/ObservationForm.tsx
@@ -5,6 +5,8 @@ import { Label } from "./ui/label";
 import { Textarea } from "./ui/textarea";
 import { useObservations } from "../context/ObservationsContext";
 import { Observation, Species } from "../types/observation";
+import { useProfiles } from "../queries/useProfiles.ts";
+import { isSupabaseConfigured } from "../lib/supabase.ts";
 import { useSpeciesSearch } from "../queries/useSpeciesSearch.ts";
 import { Controller, useForm, useWatch } from "react-hook-form";
 import {
@@ -18,7 +20,7 @@ import { Modal } from "./ui/Modal.tsx";
 import { TaxonRecord } from "../types/artsdatabanken.ts";
 import { CreateSpecies } from "../api/observations.ts";
 import SpeciesItem from "./SpeciesItem.tsx";
-import { Check, MapPin, MapPinned } from "lucide-react";
+import { Check, MapPin, MapPinned, User } from "lucide-react";
 import { twMerge } from "tailwind-merge";
 import dayjs from "dayjs";
 import { DemoContainer } from "@mui/x-date-pickers/internals/demo";
@@ -26,6 +28,9 @@ import { MobileDatePicker } from "@mui/x-date-pickers/MobileDatePicker";
 import { MobileTimePicker } from "@mui/x-date-pickers/MobileTimePicker";
 
 const DATE_TIME_STORAGE_FORMAT = "YYYY-MM-DDTHH:mm:ssZ";
+
+// Session-level memory for the last used observer name (persists across form opens, cleared on page reload)
+let sessionObserverName: string | undefined = undefined;
 
 const hasTime = (value?: string) => {
   if (!value) return false;
@@ -95,6 +100,10 @@ const ObservationForm = ({
     hasTime(observation?.endDate),
   );
 
+  const supabaseConfigured = isSupabaseConfigured();
+  const { data: profiles = [] } = useProfiles({ enabled: supabaseConfigured });
+  const [showProfileResults, setShowProfileResults] = useState(false);
+
   const { data: searchResults = [], isLoading } = useSpeciesSearch(searchTerm);
 
   // Get up to 30 most recent unique species from all observations
@@ -148,6 +157,7 @@ const ObservationForm = ({
         observation?.uncertaintyRadius ||
         presetLocation?.uncertaintyRadius ||
         100,
+      ...(!observation ? { observerName: sessionObserverName } : {}),
       ...(!observation && presetSpecies
         ? {
             species: [{ species: presetSpecies }],
@@ -269,6 +279,7 @@ const ObservationForm = ({
           endDate,
         });
       } else {
+        if (data.observerName) sessionObserverName = data.observerName;
         addObservation({
           ...data,
           locationId: presetLocation?.id,
@@ -301,6 +312,7 @@ const ObservationForm = ({
         dayjs().format(DATE_TIME_STORAGE_FORMAT);
       const endDate = toStorageDateTimeValue(data.endDate, endTimeEnabled);
 
+      if (data.observerName) sessionObserverName = data.observerName;
       addObservation({
         ...data,
         locationId: presetLocation?.id,
@@ -318,7 +330,7 @@ const ObservationForm = ({
       setSuccessMessage("Observasjon lagret!");
       setSuccessTimeout(setTimeout(() => setSuccessMessage(""), 3000));
 
-      // Reset form for a new observation, keeping location
+      // Reset form for a new observation, keeping location and observer
       const newStartDate = dayjs().toISOString();
       reset({
         startDate: newStartDate,
@@ -326,6 +338,7 @@ const ObservationForm = ({
         locationName: getValues("locationName"),
         location: currentLocation,
         uncertaintyRadius: getValues("uncertaintyRadius"),
+        observerName: sessionObserverName,
         species: [],
         comment: "",
       });
@@ -850,6 +863,98 @@ const ObservationForm = ({
               )}
             />
           </div>
+
+          <Controller
+            name={"observerName"}
+            control={control}
+            render={({ field: { value, onChange } }) => {
+              const inputValue = value ?? "";
+              const filteredProfiles =
+                inputValue.length >= 1
+                  ? profiles.filter((p) =>
+                      (p.display_name ?? p.email ?? "")
+                        .toLowerCase()
+                        .includes(inputValue.toLowerCase()),
+                    )
+                  : [];
+
+              return (
+                <div>
+                  <Label
+                    htmlFor="observerName"
+                    className="text-bark dark:text-sand"
+                  >
+                    Observatør
+                  </Label>
+                  <div className="relative mt-1">
+                    <User
+                      size={16}
+                      className="absolute left-3 top-1/2 -translate-y-1/2 text-slate pointer-events-none"
+                    />
+                    <Input
+                      id="observerName"
+                      type="text"
+                      placeholder="Navn eller velg fra liste..."
+                      value={inputValue}
+                      className={twMerge("pl-8", inputValue && "pr-8")}
+                      onChange={(e) => {
+                        onChange(e.target.value);
+                        setShowProfileResults(true);
+                      }}
+                      onFocus={() =>
+                        inputValue.length >= 1 && setShowProfileResults(true)
+                      }
+                      onBlur={() =>
+                        setTimeout(() => setShowProfileResults(false), 150)
+                      }
+                    />
+                    {inputValue && (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          onChange("");
+                          sessionObserverName = undefined;
+                          setShowProfileResults(false);
+                        }}
+                        className="absolute right-3 top-1/2 -translate-y-1/2 text-slate hover:text-bark dark:hover:text-sand"
+                        aria-label="Fjern observatør"
+                      >
+                        {"\u00d7"}
+                      </button>
+                    )}
+                  </div>
+                  {showProfileResults && filteredProfiles.length > 0 && (
+                    <div className="w-full mt-1 bg-white dark:bg-bark border-2 border-slate-border dark:border-slate rounded-md shadow-custom-lg">
+                      {filteredProfiles.map((p) => {
+                        const label = p.display_name ?? p.email ?? p.id;
+                        return (
+                          <button
+                            key={p.id}
+                            type="button"
+                            onMouseDown={(e) => e.preventDefault()}
+                            onClick={() => {
+                              onChange(label);
+                              setShowProfileResults(false);
+                            }}
+                            className="w-full text-left px-3 py-2 hover:bg-sand dark:hover:bg-forest transition-colors border-b border-slate-border dark:border-slate last:border-b-0"
+                          >
+                            <div className="font-medium text-bark dark:text-sand">
+                              {label}
+                            </div>
+                            {p.display_name && p.email && (
+                              <div className="text-xs text-slate">
+                                {p.email}
+                              </div>
+                            )}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
+              );
+            }}
+          />
 
           <Controller
             name={"comment"}

--- a/src/react-app/components/ObservationItem.tsx
+++ b/src/react-app/components/ObservationItem.tsx
@@ -7,6 +7,7 @@ import {
   Sparkles,
   Trash2,
   MapPinned,
+  User,
 } from "lucide-react";
 import { Observation } from "../types/observation";
 import { Button } from "./ui/button";
@@ -88,6 +89,12 @@ function ObservationItem({
             <p className="text-sm text-slate">
               {formatDateRange(observation.startDate, observation.endDate)}
             </p>
+            {observation.observerName && (
+              <p className="text-sm text-slate flex items-center gap-1 mt-0.5">
+                <User size={13} />
+                {observation.observerName}
+              </p>
+            )}
             {isExported && observation.lastExportedAt && (
               <p className="text-xs text-slate mt-1">
                 Sist eksportert: {formatDate(observation.lastExportedAt)}

--- a/src/react-app/queries/useProfiles.ts
+++ b/src/react-app/queries/useProfiles.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchProfiles } from "../api/profiles.ts";
+
+export function useProfiles(options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: ["profiles"],
+    queryFn: fetchProfiles,
+    enabled: options?.enabled ?? true,
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/src/react-app/types/observation.ts
+++ b/src/react-app/types/observation.ts
@@ -29,4 +29,5 @@ export interface Observation {
   lastExportedAt?: string; // ISO date string of last export, null if never exported
   exportCount?: number; // Number of times this observation has been exported
   locationId?: string;
+  observerName?: string; // Name of the observer (selected user or freetext)
 }

--- a/src/react-app/types/profile.ts
+++ b/src/react-app/types/profile.ts
@@ -1,0 +1,6 @@
+export interface Profile {
+  id: string;
+  email: string | null;
+  display_name: string | null;
+  updated_at: string;
+}

--- a/supabase/migrations/20250523000001_add_observer_name.sql
+++ b/supabase/migrations/20250523000001_add_observer_name.sql
@@ -1,0 +1,51 @@
+-- Migration: Add observer_name to observations and create profiles table
+-- Issue #133: Allow selecting an existing user or entering a freetext observer name
+
+-- 1. Add observer_name column to observations table
+ALTER TABLE observations
+  ADD COLUMN IF NOT EXISTS "observerName" text;
+
+-- 2. Create a public profiles table that mirrors basic auth.users data.
+--    Each row is auto-created/updated by a trigger when a user signs up or updates their email.
+CREATE TABLE IF NOT EXISTS profiles (
+  id         uuid PRIMARY KEY REFERENCES auth.users (id) ON DELETE CASCADE,
+  email      text,
+  display_name text,
+  updated_at timestamptz DEFAULT now()
+);
+
+-- Enable Row Level Security
+ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;
+
+-- Allow anyone (anon + authenticated) to read profiles for the observer picker
+DROP POLICY IF EXISTS "profiles_read_authenticated" ON profiles;
+DROP POLICY IF EXISTS "profiles_read_all" ON profiles;
+CREATE POLICY "profiles_read_all"
+  ON profiles FOR SELECT
+  TO anon, authenticated
+  USING (true);
+
+-- Allow users to update their own profile
+DROP POLICY IF EXISTS "profiles_update_own" ON profiles;
+CREATE POLICY "profiles_update_own"
+  ON profiles FOR UPDATE
+  TO authenticated
+  USING (auth.uid() = id)
+  WITH CHECK (auth.uid() = id);
+
+-- Allow users to insert their own profile
+DROP POLICY IF EXISTS "profiles_insert_own" ON profiles;
+CREATE POLICY "profiles_insert_own"
+  ON profiles FOR INSERT
+  TO authenticated
+  WITH CHECK (auth.uid() = id);
+
+-- 3. Back-fill profiles for any existing users
+INSERT INTO profiles (id, email, display_name, updated_at)
+  SELECT
+    id,
+    email,
+    COALESCE(raw_user_meta_data->>'full_name', email),
+    now()
+  FROM auth.users
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
## Changes

- **DB migration**: adds `observerName` text column to `observations`, creates `profiles` table (synced from `auth.users`) with RLS
- **Observer picker**: combobox in `ObservationForm` — filters existing users as you type, falls back to freetext if no match
- **Session persistence**: last used observer name pre-fills on new observations; × button clears it and resets session memory  
- **Display**: observer name shown with user icon in `ObservationItem`
- **Export**: Observatør column added as first column in Excel export

## Migration note
Run `supabase/migrations/20250523000001_add_observer_name.sql` in the Supabase SQL editor, then back-fill profiles:
```sql
INSERT INTO profiles (id, email, display_name, updated_at)
  SELECT id, email, COALESCE(raw_user_meta_data->>'full_name', email), now()
  FROM auth.users
ON CONFLICT (id) DO UPDATE SET
  email = EXCLUDED.email,
  display_name = COALESCE(raw_user_meta_data->>'full_name', EXCLUDED.email),
  updated_at = now();
```

Closes #133