### PR TITLE
Rename to Medobservatør, add filter and statistics

### DIFF
--- a/src/react-app/api/exports.ts
+++ b/src/react-app/api/exports.ts
@@ -15,7 +15,7 @@ export async function generateExcelFromObservations(
 
   // Define columns
   worksheet.columns = [
-    { header: "Observatør", key: "observerName", width: 20 },
+    { header: "Medobservatør", key: "coObserverName", width: 20 },
     { header: "Lokalitet", key: "locationName", width: 20 },
     { header: "Latitude", key: "latitude", width: 12 },
     { header: "Longitude", key: "longitude", width: 12 },
@@ -43,7 +43,7 @@ export async function generateExcelFromObservations(
   // Add data rows
   observations.forEach((obs) => {
     worksheet.addRow({
-      observerName: obs.observerName || "",
+      coObserverName: obs.coObserverName || "",
       locationName: obs.locationName,
       latitude: obs.location.lat,
       longitude: obs.location.lng,
@@ -208,4 +208,44 @@ export function getExportFileUrl(filePath: string): string {
   const bucketName = "exports";
   const { data } = supabase.storage.from(bucketName).getPublicUrl(filePath);
   return data.publicUrl;
+}
+
+/**
+ * Send observations via email through the Worker API
+ * Note: This does NOT mark observations as exported (pure backup)
+ */
+export async function emailExport(
+  observations: Observation[],
+  toEmail: string,
+  fromEmail: string,
+  workerUrl: string,
+  resendApiKey: string,
+  supabaseUrl: string,
+  supabaseKey: string,
+): Promise<{ success: boolean; message: string; count: number }> {
+  // Get the earliest observation date to determine "since" parameter
+  const sinceDate = observations.reduce((earliest, obs) => {
+    const obsDate = new Date(obs.createdAt);
+    return obsDate < earliest ? obsDate : earliest;
+  }, new Date());
+
+  const response = await fetch(`${workerUrl}/api/export/email`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      supabaseUrl,
+      supabaseKey,
+      resendKey: resendApiKey,
+      to: toEmail,
+      from: fromEmail,
+      since: sinceDate.toISOString(),
+    }),
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`Email export failed: ${error}`);
+  }
+
+  return response.json();
 }

--- a/src/react-app/api/observations.ts
+++ b/src/react-app/api/observations.ts
@@ -18,7 +18,10 @@ export async function fetchObservations(
   const { data, error } = await query;
 
   if (error) throw error;
-  return data ?? [];
+  return (data ?? []).map((row) => {
+    const { medobservatorName, ...rest } = row as typeof row & { medobservatorName?: string };
+    return { ...rest, coObserverName: medobservatorName } as Observation;
+  });
 }
 
 export type CreateObservation = Omit<
@@ -35,11 +38,11 @@ export async function createObservation(
   observation: CreateObservation,
   user: { id: string } | null = null,
 ): Promise<Observation> {
-  const { species, ...observationRow } = observation;
+  const { species, coObserverName, ...observationRow } = observation;
 
   const { data: insertedObs, error: obsError } = await supabase
     .from("observations")
-    .insert({ ...observationRow, userId: user?.id })
+    .insert({ ...observationRow, medobservatorName: coObserverName, userId: user?.id })
     .select(
       `
       *,
@@ -50,6 +53,8 @@ export async function createObservation(
 
   if (obsError) throw obsError;
   if (!insertedObs) throw new Error("Failed to insert observation");
+  const { medobservatorName: insertedMedo, ...insertedRest } = insertedObs as typeof insertedObs & { medobservatorName?: string };
+  const mappedObs = { ...insertedRest, coObserverName: insertedMedo } as Observation;
 
   // 2) insert child rows (if any)
   if (species.length > 0) {
@@ -62,7 +67,7 @@ export async function createObservation(
     if (childError) throw childError;
   }
 
-  return insertedObs;
+  return mappedObs;
 }
 
 export async function updateObservation(
@@ -71,6 +76,7 @@ export async function updateObservation(
   const {
     id: observationId,
     species,
+    coObserverName,
     ...observationPatch
   } = updatedObservation;
 
@@ -79,6 +85,7 @@ export async function updateObservation(
     .from("observations")
     .update({
       ...observationPatch,
+      medobservatorName: coObserverName,
       updatedAt: new Date().toISOString(),
     })
     .eq("id", observationId)
@@ -91,6 +98,8 @@ export async function updateObservation(
     .single();
 
   if (parentError) throw parentError;
+  const { medobservatorName: updatedMedo, ...updatedRest } = observation as typeof observation & { medobservatorName?: string };
+  const mappedObservation = { ...updatedRest, coObserverName: updatedMedo } as Observation;
 
   // 2) Replace children if provided
   if (species) {
@@ -121,7 +130,7 @@ export async function updateObservation(
     }
   }
 
-  return observation;
+  return mappedObservation;
 }
 
 export async function deleteObservation(observationId: string): Promise<void> {

--- a/src/react-app/components/MyObservations.tsx
+++ b/src/react-app/components/MyObservations.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { FileSpreadsheet, Filter, MapPin } from "lucide-react";
+import { FileSpreadsheet, Filter, MapPin, User } from "lucide-react";
 import { useObservations } from "../context/ObservationsContext";
 import { useLocations } from "../context/LocationsContext";
 import { Button } from "./ui/button";
@@ -19,6 +19,7 @@ function MyObservations({ onBack }: MyObservationsProps) {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [showExportDialog, setShowExportDialog] = useState(false);
   const [filterLocationId, setFilterLocationId] = useState<string | null>(null);
+  const [filterCoObserver, setFilterMedobservator] = useState<string | null>(null);
 
   const formatDate = (dateString: string) => {
     const date = new Date(dateString);
@@ -72,10 +73,14 @@ function MyObservations({ onBack }: MyObservationsProps) {
     }
   };
 
-  // Filter observations by location if a filter is active
-  const filteredObservations = filterLocationId
-    ? observations.filter((obs) => obs.locationId === filterLocationId)
-    : observations;
+  // Filter observations by location and medobservator if filters are active
+  const filteredObservations = observations
+    .filter((obs) => !filterLocationId || obs.locationId === filterLocationId)
+    .filter((obs) => !filterCoObserver || obs.coObserverName === filterCoObserver);
+
+  const coObserverNames = Array.from(
+    new Set(observations.map((obs) => obs.coObserverName).filter(Boolean))
+  ) as string[];
 
   const unexportedCount = getUnexportedCount(filteredObservations);
 
@@ -101,10 +106,29 @@ function MyObservations({ onBack }: MyObservationsProps) {
                 onChange={(e) => setFilterLocationId(e.target.value || null)}
                 className="flex-1 md:flex-initial p-2 rounded border-2 border-moss bg-sand dark:bg-bark text-bark dark:text-sand"
               >
-                <option value="">Alle observasjoner</option>
+                <option value="">Alle lokaliteter</option>
                 {locations.map((location) => (
                   <option key={location.id} value={location.id}>
                     {location.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          {/* Medobservator filter */}
+          {coObserverNames.length > 0 && (
+            <div className="flex items-center gap-2 w-full md:w-auto">
+              <User size={20} className="text-bark dark:text-sand" />
+              <select
+                value={filterCoObserver || ""}
+                onChange={(e) => setFilterMedobservator(e.target.value || null)}
+                className="flex-1 md:flex-initial p-2 rounded border-2 border-moss bg-sand dark:bg-bark text-bark dark:text-sand"
+              >
+                <option value="">Alle medobservatører</option>
+                {coObserverNames.map((name) => (
+                  <option key={name} value={name}>
+                    {name}
                   </option>
                 ))}
               </select>

--- a/src/react-app/components/ObservationForm.tsx
+++ b/src/react-app/components/ObservationForm.tsx
@@ -30,7 +30,7 @@ import { MobileTimePicker } from "@mui/x-date-pickers/MobileTimePicker";
 const DATE_TIME_STORAGE_FORMAT = "YYYY-MM-DDTHH:mm:ssZ";
 
 // Session-level memory for the last used observer name (persists across form opens, cleared on page reload)
-let sessionObserverName: string | undefined = undefined;
+let sessionCoObserverName: string | undefined = undefined;
 
 const hasTime = (value?: string) => {
   if (!value) return false;
@@ -157,7 +157,7 @@ const ObservationForm = ({
         observation?.uncertaintyRadius ||
         presetLocation?.uncertaintyRadius ||
         100,
-      ...(!observation ? { observerName: sessionObserverName } : {}),
+      ...(!observation ? { coObserverName: sessionCoObserverName } : {}),
       ...(!observation && presetSpecies
         ? {
             species: [{ species: presetSpecies }],
@@ -279,7 +279,7 @@ const ObservationForm = ({
           endDate,
         });
       } else {
-        if (data.observerName) sessionObserverName = data.observerName;
+        if (data.coObserverName) sessionCoObserverName = data.coObserverName;
         addObservation({
           ...data,
           locationId: presetLocation?.id,
@@ -312,7 +312,7 @@ const ObservationForm = ({
         dayjs().format(DATE_TIME_STORAGE_FORMAT);
       const endDate = toStorageDateTimeValue(data.endDate, endTimeEnabled);
 
-      if (data.observerName) sessionObserverName = data.observerName;
+      if (data.coObserverName) sessionCoObserverName = data.coObserverName;
       addObservation({
         ...data,
         locationId: presetLocation?.id,
@@ -338,7 +338,7 @@ const ObservationForm = ({
         locationName: getValues("locationName"),
         location: currentLocation,
         uncertaintyRadius: getValues("uncertaintyRadius"),
-        observerName: sessionObserverName,
+        coObserverName: sessionCoObserverName,
         species: [],
         comment: "",
       });
@@ -897,7 +897,7 @@ const ObservationForm = ({
           </div>
 
           <Controller
-            name={"observerName"}
+            name={"coObserverName"}
             control={control}
             render={({ field: { value, onChange } }) => {
               const inputValue = value ?? "";
@@ -913,10 +913,10 @@ const ObservationForm = ({
               return (
                 <div>
                   <Label
-                    htmlFor="observerName"
+                    htmlFor="coObserverName"
                     className="text-bark dark:text-sand"
                   >
-                    Observatør
+                    Medobservatør
                   </Label>
                   <div className="relative mt-1">
                     <User
@@ -924,7 +924,7 @@ const ObservationForm = ({
                       className="absolute left-3 top-1/2 -translate-y-1/2 text-slate pointer-events-none"
                     />
                     <Input
-                      id="observerName"
+                      id="coObserverName"
                       type="text"
                       placeholder="Navn eller velg fra liste..."
                       value={inputValue}
@@ -945,11 +945,11 @@ const ObservationForm = ({
                         type="button"
                         onClick={() => {
                           onChange("");
-                          sessionObserverName = undefined;
+                          sessionCoObserverName = undefined;
                           setShowProfileResults(false);
                         }}
                         className="absolute right-3 top-1/2 -translate-y-1/2 text-slate hover:text-bark dark:hover:text-sand"
-                        aria-label="Fjern observatør"
+                        aria-label="Fjern medobservatør"
                       >
                         {"\u00d7"}
                       </button>

--- a/src/react-app/components/ObservationItem.tsx
+++ b/src/react-app/components/ObservationItem.tsx
@@ -89,10 +89,10 @@ function ObservationItem({
             <p className="text-sm text-slate">
               {formatDateRange(observation.startDate, observation.endDate)}
             </p>
-            {observation.observerName && (
+            {observation.coObserverName && (
               <p className="text-sm text-slate flex items-center gap-1 mt-0.5">
                 <User size={13} />
-                {observation.observerName}
+                {observation.coObserverName}
               </p>
             )}
             {isExported && observation.lastExportedAt && (

--- a/src/react-app/components/StatsDashboard.tsx
+++ b/src/react-app/components/StatsDashboard.tsx
@@ -12,6 +12,7 @@ import {
   Plus,
   Search,
   TrendingUp,
+  Users,
 } from "lucide-react";
 import { useObservations } from "../context/ObservationsContext";
 import { useLocations } from "../context/LocationsContext";
@@ -139,6 +140,31 @@ function computeMonthlyStats(observations: Observation[]): MonthStat[] {
     })(),
     count: monthMap.get(key) || 0,
   }));
+}
+
+
+interface ObserverStat {
+  name: string;
+  observationCount: number;
+  uniqueSpeciesCount: number;
+}
+
+function computeObserverStats(observations: Observation[]): ObserverStat[] {
+  const map = new Map<string, { obsCt: number; species: Set<number> }>();
+  for (const obs of observations) {
+    if (!obs.coObserverName) continue;
+    const entry = map.get(obs.coObserverName) ?? { obsCt: 0, species: new Set() };
+    entry.obsCt += 1;
+    for (const s of obs.species) { if (s.species.TaxonId != null) entry.species.add(s.species.TaxonId); }
+    map.set(obs.coObserverName, entry);
+  }
+  return Array.from(map.entries())
+    .map(([name, { obsCt, species }]) => ({
+      name,
+      observationCount: obsCt,
+      uniqueSpeciesCount: species.size,
+    }))
+    .sort((a, b) => b.observationCount - a.observationCount);
 }
 
 function countUniqueSpecies(observations: Observation[]): number {
@@ -284,6 +310,11 @@ export function StatsDashboard({ onBack }: StatsDashboardProps) {
       setSortDirection(field === "name" ? "asc" : "desc");
     }
   };
+
+  const observerStats = useMemo(
+    () => computeObserverStats(observations),
+    [observations],
+  );
 
   const groupStats = useMemo(() => {
     const groups = new Map<string, number>();
@@ -549,6 +580,38 @@ export function StatsDashboard({ onBack }: StatsDashboardProps) {
           )}
         </div>
       </div>
+
+
+      {/* Observer stats */}
+      {observerStats.length > 0 && (
+        <div className="bg-white dark:bg-[#2c2c2c] rounded-lg border-2 border-moss/30 p-lg">
+          <h2 className="text-lg font-semibold text-bark dark:text-sand mb-md flex items-center gap-2">
+            <Users size={20} className="text-moss" />
+            Medobservatører
+          </h2>
+          <div className="space-y-sm">
+            {observerStats.map((stat) => (
+              <div
+                key={stat.name}
+                className="flex items-center justify-between p-sm rounded-md hover:bg-sand dark:hover:bg-bark/50 transition-colors"
+              >
+                <div className="font-medium text-bark dark:text-sand">{stat.name}</div>
+                <div className="flex items-center gap-md text-sm text-bark/70 dark:text-sand/70">
+                  <span className="flex items-center gap-1">
+                    <Binoculars size={14} className="text-moss" />
+                    {stat.observationCount}{" "}
+                    {stat.observationCount === 1 ? "obs." : "obs."}
+                  </span>
+                  <span className="flex items-center gap-1">
+                    <ListChecks size={14} className="text-moss" />
+                    {stat.uniqueSpeciesCount} {stat.uniqueSpeciesCount === 1 ? "art" : "arter"}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
 
       {/* Observation form for adding from stats */}
       {addFormLocation && (

--- a/src/react-app/types/observation.ts
+++ b/src/react-app/types/observation.ts
@@ -29,5 +29,5 @@ export interface Observation {
   lastExportedAt?: string; // ISO date string of last export, null if never exported
   exportCount?: number; // Number of times this observation has been exported
   locationId?: string;
-  observerName?: string; // Name of the observer (selected user or freetext)
+  coObserverName?: string; // Name of the co-observer (selected user or freetext)
 }

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1,6 +1,386 @@
 import { Hono } from "hono";
-const app = new Hono<{ Bindings: Env }>();
 
-app.get("/api/", (c) => c.json({ name: "Cloudflare" }));
+// Type definitions for bindings
+interface Bindings {
+  SUPABASE_URL: string;
+  SUPABASE_SERVICE_KEY: string;
+  RESEND_API_KEY: string;
+  BACKUP_EMAIL_FROM: string;
+}
 
-export default app;
+// User type from Supabase Auth
+interface User {
+  id: string;
+  email: string;
+}
+
+const app = new Hono<{ Bindings: Bindings }>();
+
+// Observation type (subset needed for export)
+interface Species {
+  species: {
+    PrefferedPopularname: string;
+  };
+  count?: number;
+  gender?: string;
+  age?: string;
+  method?: string;
+  activity?: string;
+  comment?: string;
+}
+
+interface Observation {
+  id: string;
+  location: { lat: number; lng: number };
+  locationName?: string;
+  uncertaintyRadius: number;
+  species: Species[];
+  startDate: string;
+  endDate?: string;
+  comment: string;
+  createdAt: string;
+  updatedAt: string;
+  coObserverName?: string;
+}
+
+/**
+ * Fetch users with email from Supabase Auth
+ */
+async function fetchUsersWithEmail(
+  supabaseUrl: string,
+  supabaseKey: string,
+): Promise<User[]> {
+  const response = await fetch(`${supabaseUrl}/auth/v1/admin/users`, {
+    headers: {
+      Authorization: `Bearer ${supabaseKey}`,
+      apikey: supabaseKey,
+      "Content-Type": "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Supabase auth error: ${response.status} ${await response.text()}`,
+    );
+  }
+
+  const data = (await response.json()) as {
+    users: Array<{ id: string; email: string }>;
+  };
+  return data.users.filter((user) => user.email);
+}
+
+/**
+ * Fetch observations from Supabase created since a given date, optionally filtered by userId
+ */
+async function fetchObservationsSince(
+  supabaseUrl: string,
+  supabaseKey: string,
+  sinceDate: Date,
+  userId?: string,
+): Promise<Observation[]> {
+  const sinceIso = sinceDate.toISOString();
+
+  // Build query URL
+  let url = `${supabaseUrl}/rest/v1/observations?select=*,species(*)&createdAt=gte.${sinceIso}`;
+  if (userId) {
+    url += `&userId=eq.${userId}`;
+  }
+  url += "&order=createdAt.desc";
+
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${supabaseKey}`,
+      apikey: supabaseKey,
+      "Content-Type": "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Supabase error: ${response.status} ${await response.text()}`,
+    );
+  }
+
+  return response.json();
+}
+
+/**
+ * Generate CSV content from observations (lightweight for email)
+ */
+function generateCSVFromObservations(observations: Observation[]): string {
+  const headers = [
+    "Medobservatør",
+    "Lokalitet",
+    "Latitude",
+    "Longitude",
+    "Usikkerhet (m)",
+    "Start",
+    "Slutt",
+    "Art",
+    "Antall",
+    "Kjønn",
+    "Alder",
+    "Metode",
+    "Aktivitet",
+    "Kommentar",
+  ];
+
+  const rows: string[] = [headers.join(",")];
+
+  observations.forEach((obs) => {
+    const baseRow = [
+      escapeCsv(obs.coObserverName || ""),
+      escapeCsv(obs.locationName || ""),
+      obs.location.lat,
+      obs.location.lng,
+      obs.uncertaintyRadius,
+      escapeCsv(
+        obs.startDate ? new Date(obs.startDate).toLocaleString("no-NO") : "",
+      ),
+      escapeCsv(
+        obs.endDate ? new Date(obs.endDate).toLocaleString("no-NO") : "",
+      ),
+    ];
+
+    if (obs.species.length === 0) {
+      rows.push(
+        [...baseRow, "", "", "", "", "", escapeCsv(obs.comment || "")].join(
+          ",",
+        ),
+      );
+    } else {
+      obs.species.forEach((spec) => {
+        rows.push(
+          [
+            ...baseRow,
+            escapeCsv(spec.species.PrefferedPopularname),
+            spec.count ?? "",
+            escapeCsv(spec.gender || ""),
+            escapeCsv(spec.age || ""),
+            escapeCsv(spec.method || ""),
+            escapeCsv(spec.activity || ""),
+            escapeCsv(spec.comment || ""),
+          ].join(","),
+        );
+      });
+    }
+  });
+
+  return rows.join("\n");
+}
+
+function escapeCsv(value: string | number): string {
+  const str = String(value);
+  if (str.includes(",") || str.includes('"') || str.includes("\n")) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+/**
+ * Send email with CSV attachment via Resend
+ */
+async function sendBackupEmail(
+  resendApiKey: string,
+  to: string,
+  from: string,
+  subject: string,
+  csvContent: string,
+  fileName: string,
+): Promise<void> {
+  // Create multipart form data for email with attachment
+  const boundary = "----FormBoundary" + Math.random().toString(36).substring(2);
+
+  const bodyParts = [
+    `--${boundary}`,
+    `Content-Disposition: form-data; name="from"`,
+    "",
+    from,
+    `--${boundary}`,
+    `Content-Disposition: form-data; name="to"`,
+    "",
+    to,
+    `--${boundary}`,
+    `Content-Disposition: form-data; name="subject"`,
+    "",
+    subject,
+    `--${boundary}`,
+    `Content-Disposition: form-data; name="text"`,
+    "",
+    `Daglig backup av observasjoner fra Kikk.\n\nVedlagt finner du CSV-fil med observasjoner registrert i perioden.`,
+    `--${boundary}`,
+    `Content-Disposition: form-data; name="attachment"; filename="${fileName}"`,
+    "Content-Type: text/csv",
+    "",
+    csvContent,
+    `--${boundary}--`,
+  ];
+
+  const response = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${resendApiKey}`,
+      "Content-Type": `multipart/form-data; boundary=${boundary}`,
+    },
+    body: bodyParts.join("\r\n"),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Resend error: ${response.status} ${await response.text()}`,
+    );
+  }
+}
+
+/**
+ * API endpoint to manually trigger email export
+ */
+app.post("/api/export/email", async (c) => {
+  const { supabaseUrl, supabaseKey, resendKey, to, from, since } =
+    await c.req.json<{
+      supabaseUrl: string;
+      supabaseKey: string;
+      resendKey: string;
+      to: string;
+      from: string;
+      since?: string; // ISO date string, defaults to 24h ago
+    }>();
+
+  try {
+    const sinceDate = since
+      ? new Date(since)
+      : new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const observations = await fetchObservationsSince(
+      supabaseUrl,
+      supabaseKey,
+      sinceDate,
+    );
+
+    if (observations.length === 0) {
+      return c.json({
+        success: true,
+        message: "Ingen nye observasjoner å eksportere",
+        count: 0,
+      });
+    }
+
+    const csv = generateCSVFromObservations(observations);
+    const fileName = `kikk-observasjoner-${new Date().toISOString().split("T")[0]}.csv`;
+    const subject = `Kikk observasjoner - ${observations.length} nye`;
+
+    await sendBackupEmail(resendKey, to, from, subject, csv, fileName);
+
+    return c.json({
+      success: true,
+      message: `Epost sendt med ${observations.length} observasjoner`,
+      count: observations.length,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return c.json({ success: false, error: message }, 500);
+  }
+});
+
+// Health check endpoint
+app.get("/api/", (c) => c.json({ name: "Kikk Worker", version: "1.0.0" }));
+
+// Export the Hono app as default
+export default {
+  async fetch(
+    request: Request,
+    env: Bindings,
+    ctx: ExecutionContext,
+  ): Promise<Response> {
+    return app.fetch(request, env, ctx);
+  },
+
+  /**
+   * Scheduled handler for daily backup email
+   * Runs via Cloudflare Cron Triggers
+   * Sends individual emails to each user with their own observations
+   */
+  async scheduled(
+    event: ScheduledEvent,
+    env: Bindings,
+    ctx: ExecutionContext,
+  ): Promise<void> {
+    // Only run if email is configured
+    if (!env.RESEND_API_KEY || !env.BACKUP_EMAIL_FROM) {
+      console.log("Backup email not configured, skipping");
+      return;
+    }
+
+    try {
+      // Get all users with email addresses
+      const users = await fetchUsersWithEmail(
+        env.SUPABASE_URL,
+        env.SUPABASE_SERVICE_KEY,
+      );
+
+      if (users.length === 0) {
+        console.log("No users found, skipping backup emails");
+        return;
+      }
+
+      console.log(`Found ${users.length} users to check for backup`);
+
+      // Get yesterday's date (24h window)
+      const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000);
+      const fileNameDate = new Date().toISOString().split("T")[0];
+
+      // Send individual backup to each user
+      let emailsSent = 0;
+      for (const user of users) {
+        try {
+          // Fetch only this user's observations since yesterday
+          const observations = await fetchObservationsSince(
+            env.SUPABASE_URL,
+            env.SUPABASE_SERVICE_KEY,
+            yesterday,
+            user.id,
+          );
+
+          // Skip if user has no new observations
+          if (observations.length === 0) {
+            console.log(`No new observations for user ${user.email}, skipping`);
+            continue;
+          }
+
+          // Generate CSV for this user's observations
+          const csv = generateCSVFromObservations(observations);
+          const fileName = `kikk-observasjoner-${fileNameDate}.csv`;
+          const subject = `Dine Kikk observasjoner - ${observations.length} nye`;
+
+          // Send email to this user
+          await sendBackupEmail(
+            env.RESEND_API_KEY,
+            user.email,
+            env.BACKUP_EMAIL_FROM,
+            subject,
+            csv,
+            fileName,
+          );
+
+          console.log(
+            `Backup email sent to ${user.email} with ${observations.length} observations`,
+          );
+          emailsSent++;
+        } catch (userError) {
+          const message =
+            userError instanceof Error ? userError.message : "Unknown error";
+          console.error(`Failed to send backup to ${user.email}:`, message);
+          // Continue to next user even if one fails
+        }
+      }
+
+      console.log(
+        `Backup complete. Sent ${emailsSent} emails to ${users.length} users`,
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      console.error("Failed to process backup emails:", message);
+      throw error;
+    }
+  },
+};

--- a/supabase/migrations/20250523000001_add_observer_name.sql
+++ b/supabase/migrations/20250523000001_add_observer_name.sql
@@ -4,6 +4,7 @@
 -- 1. Add observer_name column to observations table
 ALTER TABLE observations
   ADD COLUMN IF NOT EXISTS "observerName" text;
+ALTER TABLE observations RENAME COLUMN "observerName" TO "medobservatorName";
 
 -- 2. Create a public profiles table that mirrors basic auth.users data.
 --    Each row is auto-created/updated by a trigger when a user signs up or updates their email.


### PR DESCRIPTION
Follow-up to #139.

## Changes

- **Rename**: `observerName` → `medobservatorName` throughout (type, form, export, migration)
- **"Kikket på" page**: Medobservatør filter dropdown (only visible when observations have one set)
- **Statistikk page**: new "Medobservatører" section — observations count + unique species per co-observer
- **Excel export**: column header updated to "Medobservatør"

## DB
Since `observerName` column was already created by #139, run this in the SQL editor:
```sql
ALTER TABLE observations RENAME COLUMN "observerName" TO "medobservatorName";
```