### PR TITLE
feat: rename observer to medobservatør with persistence, stats, and map initials

### DIFF
--- a/.windsurf/workflows/feature-development.md
+++ b/.windsurf/workflows/feature-development.md
@@ -8,17 +8,22 @@ This workflow guides you through adding a new feature to kikk while maintaining 
 
 ## 1. Planning & Requirements
 
-1. **Define the feature scope**
+1. **Ask clarifying questions first**
+   - When requirements are ambiguous or incomplete, ask the user before making assumptions
+   - Examples: "Should the coordinates be shortened to 2 or 4 decimals?", "What color should the badge be?"
+   - Better to wait for clarification than to guess and rework
+
+2. **Define the feature scope**
    - What user problem are you solving?
    - What are the acceptance criteria?
    - Does it require authentication or should it work offline?
 
-2. **Identify data requirements**
+3. **Identify data requirements**
    - What data needs to be stored?
    - Does it need server-side storage or is local storage sufficient?
    - What external APIs are needed?
 
-3. **Create/Update types**
+4. **Create/Update types**
    ```typescript
    // src/react-app/types/your-feature.ts
    export interface YourFeatureType {
@@ -30,9 +35,12 @@ This workflow guides you through adding a new feature to kikk while maintaining 
 ## 2. API Layer Development
 
 1. **Create API client functions** (if external services needed)
+
    ```typescript
    // src/react-app/api/your-feature.ts
-   export async function createYourFeature(data: YourFeatureType): Promise<YourFeatureType> {
+   export async function createYourFeature(
+     data: YourFeatureType,
+   ): Promise<YourFeatureType> {
      // API call logic - NO React imports
    }
    ```
@@ -45,7 +53,7 @@ This workflow guides you through adding a new feature to kikk while maintaining 
        mutationFn: createYourFeature,
        onSuccess: () => {
          // Invalidate related queries
-       }
+       },
      });
    }
    ```
@@ -58,15 +66,21 @@ This workflow guides you through adding a new feature to kikk while maintaining 
    - Use component state for UI-only data
 
 2. **Create Context provider** (if needed)
+
    ```typescript
    // src/react-app/context/YourFeatureContext.tsx
-   export const YourFeatureProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+   export const YourFeatureProvider: React.FC<{
+     children: React.ReactNode;
+   }> = ({ children }) => {
      // Context logic with dual-mode storage support
    };
 
    export function useYourFeature() {
      const context = useContext(YourFeatureContext);
-     if (!context) throw new Error('useYourFeature must be used within YourFeatureProvider');
+     if (!context)
+       throw new Error(
+         "useYourFeature must be used within YourFeatureProvider",
+       );
      return context;
    }
    ```
@@ -88,18 +102,34 @@ This workflow guides you through adding a new feature to kikk while maintaining 
    - Mobile-first approach
    - Test on both desktop and mobile viewports
 
-## 5. Integration & Testing
+4. **Check for overlaying UI from parent components**
+   - When adding UI to a component (e.g. Map), check parent components (e.g. App.tsx) for absolute-positioned elements that might overlap
+   - Verify z-index layering and positioning (top-left, bottom-right, etc.)
+   - Test that your new UI doesn't get hidden by existing overlays
+
+## 5. Worktree Setup (if working in a git worktree)
+
+When developing in a git worktree (e.g. `git worktree add ../kikk-my-feature -b feature/my-feature`), the `.env` file is not copied automatically since it is gitignored. Symlink it from the main worktree before running `npm run dev`:
+
+```bash
+ln -s /Users/ingeborgsteel/dev/kikk/.env /Users/ingeborgsteel/dev/kikk-my-feature/.env
+npm install
+npm run dev
+```
+
+## 6. Integration & Testing
 
 1. **Integrate with routing**
    - Add routes in `App.tsx` if needed
    - Update navigation components
 
 2. **Test dual-mode operation**
+
    ```bash
    # Test without Supabase
    unset VITE_SUPABASE_URL VITE_SUPABASE_ANON_KEY
    npm run dev
-   
+
    # Test with Supabase
    # Set environment variables and test again
    ```
@@ -138,6 +168,7 @@ npm run format    # Ensure consistent formatting
 ## Common Patterns to Follow
 
 ### Form Pattern
+
 ```typescript
 // Always use React Hook Form
 const { control, handleSubmit, formState: { errors } } = useForm<YourFormType>();
@@ -153,17 +184,19 @@ const { control, handleSubmit, formState: { errors } } = useForm<YourFormType>()
 ```
 
 ### API Error Handling Pattern
+
 ```typescript
 try {
   const result = await apiCall();
   return result;
 } catch (error) {
-  console.error('API call failed:', error);
-  throw new Error('User-friendly error message');
+  console.error("API call failed:", error);
+  throw new Error("User-friendly error message");
 }
 ```
 
 ### Dual-Mode Storage Pattern
+
 ```typescript
 const saveData = async (data: YourType) => {
   if (isSupabaseConfigured()) {
@@ -171,7 +204,7 @@ const saveData = async (data: YourType) => {
     return await saveToSupabase(data);
   } else {
     // Use localStorage
-    localStorage.setItem('kikk_your_feature', JSON.stringify(data));
+    localStorage.setItem("kikk_your_feature", JSON.stringify(data));
     return data;
   }
 };

--- a/.windsurf/workflows/feature-development.md
+++ b/.windsurf/workflows/feature-development.md
@@ -117,6 +117,13 @@ npm install
 npm run dev
 ```
 
+**CRITICAL: Stay in the worktree directory**
+
+- All file edits MUST be made within the worktree directory (e.g., `/Users/ingeborgsteel/dev/kikk-my-feature/`)
+- Do NOT mix edits between the main repo and the worktree
+- Always verify `pwd` shows the worktree path before editing files
+- If you accidentally edit the main repo instead, copy those changes to the worktree and commit from there
+
 ## 6. Integration & Testing
 
 1. **Integrate with routing**

--- a/src/react-app/Map.tsx
+++ b/src/react-app/Map.tsx
@@ -684,27 +684,6 @@ function Map({
           <span>Sentrert på din posisjon</span>
         </div>
       )}
-      {selectedLocation && (
-        <div
-          className={`absolute ${isOnline ? "top-md" : "top-[calc(1rem+26px)]"} left-1/2 -translate-x-1/2 z-[500] bg-sand dark:bg-[rgba(44,44,44,0.95)] p-sm rounded-lg shadow-custom-xl flex items-center gap-sm text-sm md:text-base font-semibold text-bark dark:text-sand animate-[slideDown_0.3s_ease] max-w-[90%] border-2 border-moss`}
-        >
-          <svg
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            className="text-rust shrink-0"
-          >
-            <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z" />
-            <circle cx="12" cy="10" r="3" />
-          </svg>
-          <span>
-            {selectedLocation.lat.toFixed(4)}, {selectedLocation.lng.toFixed(4)}
-          </span>
-        </div>
-      )}
       {/* Download area button */}
       <div className="absolute bottom-md left-md z-[500]">
         {downloadProgress ? (
@@ -742,6 +721,30 @@ function Map({
         ref={mapContainer}
         className="absolute inset-0 w-full h-full border-none rounded-t-lg overflow-hidden"
       />
+
+      {/* Active medobservatør badge (above download button) */}
+      {(() => {
+        const medobs = localStorage.getItem("kikk-medobservator");
+        if (!medobs) return null;
+        return (
+          <div className="absolute bottom-[calc(1rem+44px)] left-md z-[500] bg-forest/90 text-sand text-xs font-medium px-3 py-2 rounded-lg shadow-custom-lg flex items-center gap-2">
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
+              <circle cx="12" cy="8" r="5" />
+              <path d="M20 21a8 8 0 0 0-16 0" />
+            </svg>
+            <span className="max-w-[150px] truncate" title={medobs}>
+              {medobs}
+            </span>
+          </div>
+        );
+      })()}
     </div>
   );
 }

--- a/src/react-app/Map.tsx
+++ b/src/react-app/Map.tsx
@@ -21,7 +21,7 @@ import {
   mapboxTopo,
 } from "./lib/mapUtils.ts";
 import {
-  createObservationIcon,
+  createObservationIconWithInitials,
   createSelectionIcon,
   createUserLocationIcon,
 } from "./lib/markerIcons.ts";
@@ -37,7 +37,6 @@ const DefaultIcon = L.icon({
 
 // Create icon instances for use in the map
 const SelectionIcon = createSelectionIcon();
-const ObservationIcon = createObservationIcon();
 const UserLocationIcon = createUserLocationIcon();
 
 L.Marker.prototype.options.icon = DefaultIcon;
@@ -461,7 +460,7 @@ function Map({
       if (map.current) {
         const marker = L.marker(
           [observation.location.lat, observation.location.lng],
-          { icon: ObservationIcon },
+          { icon: createObservationIconWithInitials(observation.observerName) },
         ).addTo(map.current);
 
         // Create popup content
@@ -473,10 +472,15 @@ function Map({
           )
           .join(", ");
 
+        const speciesCount = observation.species?.length || 0;
+        const speciesCountText =
+          speciesCount === 1 ? "1 art" : `${speciesCount} arter`;
+
         const popupContent = `
           <div style="min-width: 150px;">
+            <small style="color: #2F5D50; font-weight: 600;">${speciesCountText}</small><br/>
             <strong>${speciesList}</strong><br/>
-            ${observation.startDate ? `<small>${new Date(observation.startDate).toLocaleDateString("no-NO")}</small><br/>` : null}
+            ${observation.startDate ? `<small>${new Date(observation.startDate).toLocaleDateString("no-NO")}</small><br/>` : ""}
             <small>±${observation.uncertaintyRadius}m</small>
           </div>
         `;
@@ -499,6 +503,17 @@ function Map({
   useEffect(() => {
     if (!map.current) return;
 
+    // Count observations per location
+    const obsCountByLocation = new globalThis.Map<string, number>();
+    for (const obs of observations) {
+      if (obs.locationId) {
+        obsCountByLocation.set(
+          obs.locationId,
+          (obsCountByLocation.get(obs.locationId) || 0) + 1,
+        );
+      }
+    }
+
     // Remove existing user location markers
     userLocationsMarkersRef.current.forEach((marker) => marker.remove());
     userLocationsMarkersRef.current = [];
@@ -510,11 +525,16 @@ function Map({
           icon: UserLocationIcon,
         }).addTo(map.current);
 
-        // Create popup content
+        // Create popup content with observation count
+        const obsCount = obsCountByLocation.get(userLoc.id || "") || 0;
+        const obsCountText =
+          obsCount === 1 ? "1 observasjon" : `${obsCount} observasjoner`;
+
         const popupContent = `
           <div style="min-width: 150px;">
             <strong>${userLoc.name}</strong><br/>
             ${userLoc.description ? `<small>${userLoc.description}</small><br/>` : ""}
+            <small style="color: #7C3AED; font-weight: 500;">${obsCountText}</small><br/>
             <small>±${userLoc.uncertaintyRadius}m</small>
           </div>
         `;
@@ -531,7 +551,7 @@ function Map({
         userLocationsMarkersRef.current.push(marker);
       }
     });
-  }, [userLocations, onUserLocationClick]);
+  }, [userLocations, onUserLocationClick, observations]);
 
   // Effect to handle layer switching
   useEffect(() => {

--- a/src/react-app/api/exports.ts
+++ b/src/react-app/api/exports.ts
@@ -15,7 +15,7 @@ export async function generateExcelFromObservations(
 
   // Define columns
   worksheet.columns = [
-    { header: "Observatør", key: "observerName", width: 20 },
+    { header: "Medobservatør", key: "observerName", width: 20 },
     { header: "Lokalitet", key: "locationName", width: 20 },
     { header: "Latitude", key: "latitude", width: 12 },
     { header: "Longitude", key: "longitude", width: 12 },

--- a/src/react-app/components/ObservationForm.tsx
+++ b/src/react-app/components/ObservationForm.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import { Label } from "./ui/label";
@@ -87,7 +87,6 @@ const ObservationForm = ({
   );
   const [geocodingFailed, setGeocodingFailed] = useState(false);
   const [currentLocation, setCurrentLocation] = useState(location);
-  const originalLocationRef = useRef(location);
   const [successMessage, setSuccessMessage] = useState("");
   const [successTimeout, setSuccessTimeout] = useState<ReturnType<
     typeof setTimeout
@@ -394,34 +393,13 @@ const ObservationForm = ({
                 <Button
                   type="button"
                   variant="secondary"
-                  disabled={
-                    (!isDirty &&
-                      Math.abs(
-                        originalLocationRef.current.lat - currentLocation.lat,
-                      ) < 0.0001 &&
-                      Math.abs(
-                        originalLocationRef.current.lng - currentLocation.lng,
-                      ) < 0.0001) ||
-                    !isValid
-                  }
+                  disabled={!isDirty || !isValid}
                   onClick={handleSubmit(saveAndAddAnother)}
                 >
                   Lagre og legg til ny
                 </Button>
               )}
-              <Button
-                type="submit"
-                disabled={
-                  (!isDirty &&
-                    Math.abs(
-                      originalLocationRef.current.lat - currentLocation.lat,
-                    ) < 0.0001 &&
-                    Math.abs(
-                      originalLocationRef.current.lng - currentLocation.lng,
-                    ) < 0.0001) ||
-                  !isValid
-                }
-              >
+              <Button type="submit" disabled={!isDirty || !isValid}>
                 Lagre
               </Button>
             </div>

--- a/src/react-app/components/ObservationForm.tsx
+++ b/src/react-app/components/ObservationForm.tsx
@@ -29,8 +29,23 @@ import { MobileTimePicker } from "@mui/x-date-pickers/MobileTimePicker";
 
 const DATE_TIME_STORAGE_FORMAT = "YYYY-MM-DDTHH:mm:ssZ";
 
-// Session-level memory for the last used observer name (persists across form opens, cleared on page reload)
-let sessionObserverName: string | undefined = undefined;
+const MEDOBSERVATOR_STORAGE_KEY = "kikk-medobservator";
+
+function getStoredMedobservator(): string | undefined {
+  const value = localStorage.getItem(MEDOBSERVATOR_STORAGE_KEY);
+  console.log("[Medobservator] Getting stored value:", value);
+  return value || undefined;
+}
+
+function setStoredMedobservator(name: string | undefined) {
+  if (name) {
+    console.log("[Medobservator] Storing:", name);
+    localStorage.setItem(MEDOBSERVATOR_STORAGE_KEY, name);
+  } else {
+    console.log("[Medobservator] Clearing stored value");
+    localStorage.removeItem(MEDOBSERVATOR_STORAGE_KEY);
+  }
+}
 
 const hasTime = (value?: string) => {
   if (!value) return false;
@@ -157,7 +172,7 @@ const ObservationForm = ({
         observation?.uncertaintyRadius ||
         presetLocation?.uncertaintyRadius ||
         100,
-      ...(!observation ? { observerName: sessionObserverName } : {}),
+      ...(!observation ? { observerName: getStoredMedobservator() } : {}),
       ...(!observation && presetSpecies
         ? {
             species: [{ species: presetSpecies }],
@@ -271,6 +286,11 @@ const ObservationForm = ({
         dayjs().format(DATE_TIME_STORAGE_FORMAT);
       const endDate = toStorageDateTimeValue(data.endDate, endTimeEnabled);
 
+      // Persist medobservator whenever there's a value (new or edit)
+      if (data.observerName?.trim()) {
+        setStoredMedobservator(data.observerName.trim());
+      }
+
       if (data.id) {
         updateObservation({
           ...data,
@@ -279,7 +299,6 @@ const ObservationForm = ({
           endDate,
         });
       } else {
-        if (data.observerName) sessionObserverName = data.observerName;
         addObservation({
           ...data,
           locationId: presetLocation?.id,
@@ -312,7 +331,10 @@ const ObservationForm = ({
         dayjs().format(DATE_TIME_STORAGE_FORMAT);
       const endDate = toStorageDateTimeValue(data.endDate, endTimeEnabled);
 
-      if (data.observerName) sessionObserverName = data.observerName;
+      // Only store if there's a value (don't clear existing on empty)
+      if (data.observerName?.trim()) {
+        setStoredMedobservator(data.observerName.trim());
+      }
       addObservation({
         ...data,
         locationId: presetLocation?.id,
@@ -338,7 +360,7 @@ const ObservationForm = ({
         locationName: getValues("locationName"),
         location: currentLocation,
         uncertaintyRadius: getValues("uncertaintyRadius"),
-        observerName: sessionObserverName,
+        observerName: getStoredMedobservator(),
         species: [],
         comment: "",
       });
@@ -619,6 +641,99 @@ const ObservationForm = ({
             }}
           />
 
+          <Controller
+            name={"observerName"}
+            control={control}
+            render={({ field: { value, onChange } }) => {
+              const inputValue = value ?? "";
+              const filteredProfiles =
+                inputValue.length >= 1
+                  ? profiles.filter((p) =>
+                      (p.display_name ?? p.email ?? "")
+                        .toLowerCase()
+                        .includes(inputValue.toLowerCase()),
+                    )
+                  : [];
+
+              return (
+                <div>
+                  <Label
+                    htmlFor="observerName"
+                    className="text-bark dark:text-sand"
+                  >
+                    Medobservatør
+                  </Label>
+                  <div className="relative mt-1">
+                    <User
+                      size={16}
+                      className="absolute left-3 top-1/2 -translate-y-1/2 text-slate pointer-events-none"
+                    />
+                    <Input
+                      id="observerName"
+                      type="text"
+                      placeholder="Navn eller velg fra liste..."
+                      value={inputValue}
+                      className={twMerge("pl-8", inputValue && "pr-8")}
+                      onChange={(e) => {
+                        onChange(e.target.value);
+                        setShowProfileResults(true);
+                      }}
+                      onFocus={() =>
+                        inputValue.length >= 1 && setShowProfileResults(true)
+                      }
+                      onBlur={() =>
+                        setTimeout(() => setShowProfileResults(false), 150)
+                      }
+                    />
+                    {inputValue && (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          onChange("");
+                          setStoredMedobservator(undefined);
+                          setShowProfileResults(false);
+                        }}
+                        className="absolute right-3 top-1/2 -translate-y-1/2 text-slate hover:text-bark dark:hover:text-sand"
+                        aria-label="Fjern medobservatør"
+                      >
+                        {"\u00d7"}
+                      </button>
+                    )}
+                  </div>
+                  {showProfileResults && filteredProfiles.length > 0 && (
+                    <div className="w-full mt-1 bg-white dark:bg-bark border-2 border-slate-border dark:border-slate rounded-md shadow-custom-lg">
+                      {filteredProfiles.map((p) => {
+                        const label = p.display_name ?? p.email ?? p.id;
+                        return (
+                          <button
+                            key={p.id}
+                            type="button"
+                            onMouseDown={(e) => e.preventDefault()}
+                            onClick={() => {
+                              onChange(label);
+                              setStoredMedobservator(label);
+                              setShowProfileResults(false);
+                            }}
+                            className="w-full text-left px-3 py-2 hover:bg-sand dark:hover:bg-forest transition-colors border-b border-slate-border dark:border-slate last:border-b-0"
+                          >
+                            <div className="font-medium text-bark dark:text-sand">
+                              {label}
+                            </div>
+                            {p.display_name && p.email && (
+                              <div className="text-xs text-slate">
+                                {p.email}
+                              </div>
+                            )}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
+              );
+            }}
+          />
+
           <div>
             <Controller
               name={"locationName"}
@@ -895,98 +1010,6 @@ const ObservationForm = ({
               )}
             />
           </div>
-
-          <Controller
-            name={"observerName"}
-            control={control}
-            render={({ field: { value, onChange } }) => {
-              const inputValue = value ?? "";
-              const filteredProfiles =
-                inputValue.length >= 1
-                  ? profiles.filter((p) =>
-                      (p.display_name ?? p.email ?? "")
-                        .toLowerCase()
-                        .includes(inputValue.toLowerCase()),
-                    )
-                  : [];
-
-              return (
-                <div>
-                  <Label
-                    htmlFor="observerName"
-                    className="text-bark dark:text-sand"
-                  >
-                    Observatør
-                  </Label>
-                  <div className="relative mt-1">
-                    <User
-                      size={16}
-                      className="absolute left-3 top-1/2 -translate-y-1/2 text-slate pointer-events-none"
-                    />
-                    <Input
-                      id="observerName"
-                      type="text"
-                      placeholder="Navn eller velg fra liste..."
-                      value={inputValue}
-                      className={twMerge("pl-8", inputValue && "pr-8")}
-                      onChange={(e) => {
-                        onChange(e.target.value);
-                        setShowProfileResults(true);
-                      }}
-                      onFocus={() =>
-                        inputValue.length >= 1 && setShowProfileResults(true)
-                      }
-                      onBlur={() =>
-                        setTimeout(() => setShowProfileResults(false), 150)
-                      }
-                    />
-                    {inputValue && (
-                      <button
-                        type="button"
-                        onClick={() => {
-                          onChange("");
-                          sessionObserverName = undefined;
-                          setShowProfileResults(false);
-                        }}
-                        className="absolute right-3 top-1/2 -translate-y-1/2 text-slate hover:text-bark dark:hover:text-sand"
-                        aria-label="Fjern observatør"
-                      >
-                        {"\u00d7"}
-                      </button>
-                    )}
-                  </div>
-                  {showProfileResults && filteredProfiles.length > 0 && (
-                    <div className="w-full mt-1 bg-white dark:bg-bark border-2 border-slate-border dark:border-slate rounded-md shadow-custom-lg">
-                      {filteredProfiles.map((p) => {
-                        const label = p.display_name ?? p.email ?? p.id;
-                        return (
-                          <button
-                            key={p.id}
-                            type="button"
-                            onMouseDown={(e) => e.preventDefault()}
-                            onClick={() => {
-                              onChange(label);
-                              setShowProfileResults(false);
-                            }}
-                            className="w-full text-left px-3 py-2 hover:bg-sand dark:hover:bg-forest transition-colors border-b border-slate-border dark:border-slate last:border-b-0"
-                          >
-                            <div className="font-medium text-bark dark:text-sand">
-                              {label}
-                            </div>
-                            {p.display_name && p.email && (
-                              <div className="text-xs text-slate">
-                                {p.email}
-                              </div>
-                            )}
-                          </button>
-                        );
-                      })}
-                    </div>
-                  )}
-                </div>
-              );
-            }}
-          />
 
           <Controller
             name={"comment"}

--- a/src/react-app/components/ObservationForm.tsx
+++ b/src/react-app/components/ObservationForm.tsx
@@ -230,12 +230,23 @@ const ObservationForm = ({
     };
   }, [successTimeout]);
 
+  // Reset dirty state after mount for new observations
+  // so prefilled defaults don't trigger "unsaved changes" warning
+  useEffect(() => {
+    if (!observation) {
+      const timer = setTimeout(() => {
+        reset(getValues(), { keepValues: true });
+      }, 100);
+      return () => clearTimeout(timer);
+    }
+  }, [observation, reset, getValues]);
+
   // Fetch location name when form opens for a new observation
   useEffect(() => {
     const currentLocationName = getValues("locationName");
     // When a preset location is set, use its name
     if (presetLocation) {
-      setValue("locationName", presetLocation.name, { shouldDirty: true });
+      setValue("locationName", presetLocation.name, { shouldDirty: false });
       return;
     }
     // Only fetch if this is a new observation, locationName is not yet set
@@ -243,7 +254,7 @@ const ObservationForm = ({
       reverseGeocode(currentLocation.lat, currentLocation.lng)
         .then((name) => {
           if (name) {
-            setValue("locationName", name);
+            setValue("locationName", name, { shouldDirty: false });
             setGeocodingFailed(false);
           } else {
             setGeocodingFailed(true);
@@ -263,7 +274,7 @@ const ObservationForm = ({
   useEffect(() => {
     if (startDate && !observation) {
       // Only auto-update for new observations
-      setValue("endDate", startDate);
+      setValue("endDate", startDate, { shouldDirty: false });
     }
   }, [startDate, setValue, observation]);
 
@@ -367,12 +378,14 @@ const ObservationForm = ({
       <Modal
         isOpen={isOpen}
         onClose={() => {
-          if (
-            !isDirty ||
-            confirm(
-              "Er du sikker på at du vil lukke? Alle endringer vil gå tapt.",
-            )
-          ) {
+          if (!isDirty) {
+            onClose();
+            return;
+          }
+          const confirmed = confirm(
+            "Er du sikker på at du vil lukke? Alle endringer vil gå tapt.",
+          );
+          if (confirmed) {
             onClose();
           }
         }}

--- a/src/react-app/components/ObservationForm.tsx
+++ b/src/react-app/components/ObservationForm.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import { Label } from "./ui/label";
@@ -29,23 +29,8 @@ import { MobileTimePicker } from "@mui/x-date-pickers/MobileTimePicker";
 
 const DATE_TIME_STORAGE_FORMAT = "YYYY-MM-DDTHH:mm:ssZ";
 
-const MEDOBSERVATOR_STORAGE_KEY = "kikk-medobservator";
-
-function getStoredMedobservator(): string | undefined {
-  const value = localStorage.getItem(MEDOBSERVATOR_STORAGE_KEY);
-  console.log("[Medobservator] Getting stored value:", value);
-  return value || undefined;
-}
-
-function setStoredMedobservator(name: string | undefined) {
-  if (name) {
-    console.log("[Medobservator] Storing:", name);
-    localStorage.setItem(MEDOBSERVATOR_STORAGE_KEY, name);
-  } else {
-    console.log("[Medobservator] Clearing stored value");
-    localStorage.removeItem(MEDOBSERVATOR_STORAGE_KEY);
-  }
-}
+// Session-level memory for the last used observer name (persists across form opens, cleared on page reload)
+let sessionObserverName: string | undefined = undefined;
 
 const hasTime = (value?: string) => {
   if (!value) return false;
@@ -102,6 +87,7 @@ const ObservationForm = ({
   );
   const [geocodingFailed, setGeocodingFailed] = useState(false);
   const [currentLocation, setCurrentLocation] = useState(location);
+  const originalLocationRef = useRef(location);
   const [successMessage, setSuccessMessage] = useState("");
   const [successTimeout, setSuccessTimeout] = useState<ReturnType<
     typeof setTimeout
@@ -172,7 +158,7 @@ const ObservationForm = ({
         observation?.uncertaintyRadius ||
         presetLocation?.uncertaintyRadius ||
         100,
-      ...(!observation ? { observerName: getStoredMedobservator() } : {}),
+      ...(!observation ? { observerName: sessionObserverName } : {}),
       ...(!observation && presetSpecies
         ? {
             species: [{ species: presetSpecies }],
@@ -198,7 +184,10 @@ const ObservationForm = ({
 
       const newLocation = { lat, lng };
       setCurrentLocation(newLocation);
-      setValue("location", newLocation);
+      setValue("location", newLocation, {
+        shouldDirty: true,
+        shouldValidate: true,
+      });
 
       // Re-fetch location name when position changes significantly (> 100m)
       const distance = Math.sqrt(
@@ -286,11 +275,6 @@ const ObservationForm = ({
         dayjs().format(DATE_TIME_STORAGE_FORMAT);
       const endDate = toStorageDateTimeValue(data.endDate, endTimeEnabled);
 
-      // Persist medobservator whenever there's a value (new or edit)
-      if (data.observerName?.trim()) {
-        setStoredMedobservator(data.observerName.trim());
-      }
-
       if (data.id) {
         updateObservation({
           ...data,
@@ -299,6 +283,7 @@ const ObservationForm = ({
           endDate,
         });
       } else {
+        if (data.observerName) sessionObserverName = data.observerName;
         addObservation({
           ...data,
           locationId: presetLocation?.id,
@@ -331,10 +316,7 @@ const ObservationForm = ({
         dayjs().format(DATE_TIME_STORAGE_FORMAT);
       const endDate = toStorageDateTimeValue(data.endDate, endTimeEnabled);
 
-      // Only store if there's a value (don't clear existing on empty)
-      if (data.observerName?.trim()) {
-        setStoredMedobservator(data.observerName.trim());
-      }
+      if (data.observerName) sessionObserverName = data.observerName;
       addObservation({
         ...data,
         locationId: presetLocation?.id,
@@ -360,7 +342,7 @@ const ObservationForm = ({
         locationName: getValues("locationName"),
         location: currentLocation,
         uncertaintyRadius: getValues("uncertaintyRadius"),
-        observerName: getStoredMedobservator(),
+        observerName: sessionObserverName,
         species: [],
         comment: "",
       });
@@ -412,13 +394,34 @@ const ObservationForm = ({
                 <Button
                   type="button"
                   variant="secondary"
-                  disabled={!isDirty || !isValid}
+                  disabled={
+                    (!isDirty &&
+                      Math.abs(
+                        originalLocationRef.current.lat - currentLocation.lat,
+                      ) < 0.0001 &&
+                      Math.abs(
+                        originalLocationRef.current.lng - currentLocation.lng,
+                      ) < 0.0001) ||
+                    !isValid
+                  }
                   onClick={handleSubmit(saveAndAddAnother)}
                 >
                   Lagre og legg til ny
                 </Button>
               )}
-              <Button type="submit" disabled={!isDirty || !isValid}>
+              <Button
+                type="submit"
+                disabled={
+                  (!isDirty &&
+                    Math.abs(
+                      originalLocationRef.current.lat - currentLocation.lat,
+                    ) < 0.0001 &&
+                    Math.abs(
+                      originalLocationRef.current.lng - currentLocation.lng,
+                    ) < 0.0001) ||
+                  !isValid
+                }
+              >
                 Lagre
               </Button>
             </div>
@@ -938,7 +941,7 @@ const ObservationForm = ({
                     htmlFor="observerName"
                     className="text-bark dark:text-sand"
                   >
-                    Medobservatør
+                    Observatør
                   </Label>
                   <div className="relative mt-1">
                     <User
@@ -967,11 +970,11 @@ const ObservationForm = ({
                         type="button"
                         onClick={() => {
                           onChange("");
-                          setStoredMedobservator(undefined);
+                          sessionObserverName = undefined;
                           setShowProfileResults(false);
                         }}
                         className="absolute right-3 top-1/2 -translate-y-1/2 text-slate hover:text-bark dark:hover:text-sand"
-                        aria-label="Fjern medobservatør"
+                        aria-label="Fjern observatør"
                       >
                         {"\u00d7"}
                       </button>
@@ -988,7 +991,6 @@ const ObservationForm = ({
                             onMouseDown={(e) => e.preventDefault()}
                             onClick={() => {
                               onChange(label);
-                              setStoredMedobservator(label);
                               setShowProfileResults(false);
                             }}
                             className="w-full text-left px-3 py-2 hover:bg-sand dark:hover:bg-forest transition-colors border-b border-slate-border dark:border-slate last:border-b-0"

--- a/src/react-app/components/ObservationForm.tsx
+++ b/src/react-app/components/ObservationForm.tsx
@@ -641,99 +641,6 @@ const ObservationForm = ({
             }}
           />
 
-          <Controller
-            name={"observerName"}
-            control={control}
-            render={({ field: { value, onChange } }) => {
-              const inputValue = value ?? "";
-              const filteredProfiles =
-                inputValue.length >= 1
-                  ? profiles.filter((p) =>
-                      (p.display_name ?? p.email ?? "")
-                        .toLowerCase()
-                        .includes(inputValue.toLowerCase()),
-                    )
-                  : [];
-
-              return (
-                <div>
-                  <Label
-                    htmlFor="observerName"
-                    className="text-bark dark:text-sand"
-                  >
-                    Medobservatør
-                  </Label>
-                  <div className="relative mt-1">
-                    <User
-                      size={16}
-                      className="absolute left-3 top-1/2 -translate-y-1/2 text-slate pointer-events-none"
-                    />
-                    <Input
-                      id="observerName"
-                      type="text"
-                      placeholder="Navn eller velg fra liste..."
-                      value={inputValue}
-                      className={twMerge("pl-8", inputValue && "pr-8")}
-                      onChange={(e) => {
-                        onChange(e.target.value);
-                        setShowProfileResults(true);
-                      }}
-                      onFocus={() =>
-                        inputValue.length >= 1 && setShowProfileResults(true)
-                      }
-                      onBlur={() =>
-                        setTimeout(() => setShowProfileResults(false), 150)
-                      }
-                    />
-                    {inputValue && (
-                      <button
-                        type="button"
-                        onClick={() => {
-                          onChange("");
-                          setStoredMedobservator(undefined);
-                          setShowProfileResults(false);
-                        }}
-                        className="absolute right-3 top-1/2 -translate-y-1/2 text-slate hover:text-bark dark:hover:text-sand"
-                        aria-label="Fjern medobservatør"
-                      >
-                        {"\u00d7"}
-                      </button>
-                    )}
-                  </div>
-                  {showProfileResults && filteredProfiles.length > 0 && (
-                    <div className="w-full mt-1 bg-white dark:bg-bark border-2 border-slate-border dark:border-slate rounded-md shadow-custom-lg">
-                      {filteredProfiles.map((p) => {
-                        const label = p.display_name ?? p.email ?? p.id;
-                        return (
-                          <button
-                            key={p.id}
-                            type="button"
-                            onMouseDown={(e) => e.preventDefault()}
-                            onClick={() => {
-                              onChange(label);
-                              setStoredMedobservator(label);
-                              setShowProfileResults(false);
-                            }}
-                            className="w-full text-left px-3 py-2 hover:bg-sand dark:hover:bg-forest transition-colors border-b border-slate-border dark:border-slate last:border-b-0"
-                          >
-                            <div className="font-medium text-bark dark:text-sand">
-                              {label}
-                            </div>
-                            {p.display_name && p.email && (
-                              <div className="text-xs text-slate">
-                                {p.email}
-                              </div>
-                            )}
-                          </button>
-                        );
-                      })}
-                    </div>
-                  )}
-                </div>
-              );
-            }}
-          />
-
           <div>
             <Controller
               name={"locationName"}
@@ -1010,6 +917,99 @@ const ObservationForm = ({
               )}
             />
           </div>
+
+          <Controller
+            name={"observerName"}
+            control={control}
+            render={({ field: { value, onChange } }) => {
+              const inputValue = value ?? "";
+              const filteredProfiles =
+                inputValue.length >= 1
+                  ? profiles.filter((p) =>
+                      (p.display_name ?? p.email ?? "")
+                        .toLowerCase()
+                        .includes(inputValue.toLowerCase()),
+                    )
+                  : [];
+
+              return (
+                <div>
+                  <Label
+                    htmlFor="observerName"
+                    className="text-bark dark:text-sand"
+                  >
+                    Medobservatør
+                  </Label>
+                  <div className="relative mt-1">
+                    <User
+                      size={16}
+                      className="absolute left-3 top-1/2 -translate-y-1/2 text-slate pointer-events-none"
+                    />
+                    <Input
+                      id="observerName"
+                      type="text"
+                      placeholder="Navn eller velg fra liste..."
+                      value={inputValue}
+                      className={twMerge("pl-8", inputValue && "pr-8")}
+                      onChange={(e) => {
+                        onChange(e.target.value);
+                        setShowProfileResults(true);
+                      }}
+                      onFocus={() =>
+                        inputValue.length >= 1 && setShowProfileResults(true)
+                      }
+                      onBlur={() =>
+                        setTimeout(() => setShowProfileResults(false), 150)
+                      }
+                    />
+                    {inputValue && (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          onChange("");
+                          setStoredMedobservator(undefined);
+                          setShowProfileResults(false);
+                        }}
+                        className="absolute right-3 top-1/2 -translate-y-1/2 text-slate hover:text-bark dark:hover:text-sand"
+                        aria-label="Fjern medobservatør"
+                      >
+                        {"\u00d7"}
+                      </button>
+                    )}
+                  </div>
+                  {showProfileResults && filteredProfiles.length > 0 && (
+                    <div className="w-full mt-1 bg-white dark:bg-bark border-2 border-slate-border dark:border-slate rounded-md shadow-custom-lg">
+                      {filteredProfiles.map((p) => {
+                        const label = p.display_name ?? p.email ?? p.id;
+                        return (
+                          <button
+                            key={p.id}
+                            type="button"
+                            onMouseDown={(e) => e.preventDefault()}
+                            onClick={() => {
+                              onChange(label);
+                              setStoredMedobservator(label);
+                              setShowProfileResults(false);
+                            }}
+                            className="w-full text-left px-3 py-2 hover:bg-sand dark:hover:bg-forest transition-colors border-b border-slate-border dark:border-slate last:border-b-0"
+                          >
+                            <div className="font-medium text-bark dark:text-sand">
+                              {label}
+                            </div>
+                            {p.display_name && p.email && (
+                              <div className="text-xs text-slate">
+                                {p.email}
+                              </div>
+                            )}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
+              );
+            }}
+          />
 
           <Controller
             name={"comment"}

--- a/src/react-app/components/ObservationItem.tsx
+++ b/src/react-app/components/ObservationItem.tsx
@@ -26,7 +26,6 @@ function ObservationItem({
   onEdit,
   onDelete,
   formatDate,
-  formatDateRange,
 }: ObservationItemProps) {
   // Automatically collapse exported observations
   const [isExpanded, setIsExpanded] = useState(!observation.lastExportedAt);
@@ -53,7 +52,8 @@ function ObservationItem({
         onClick={() => isExported && setIsExpanded(!isExpanded)}
       >
         <div className="flex justify-between items-center">
-          <div className="flex-1">
+          <div className="flex-1 space-y-1">
+            {/* Location name + pills row */}
             <div className="flex items-center gap-sm flex-wrap">
               {observation.locationName && (
                 <div className="font-medium text-bark flex items-center gap-1">
@@ -73,7 +73,7 @@ function ObservationItem({
               </span>
               {observation.observerName && (
                 <span
-                  className="inline-flex items-center gap-1 px-2 py-0.5 bg-forest/20 text-bark dark:text-sand text-xs rounded-full"
+                  className="inline-flex items-center gap-1 px-2 py-0.5 bg-moss/20 text-bark dark:text-sand text-xs rounded-full"
                   title={observation.observerName}
                 >
                   <User size={12} />
@@ -81,29 +81,54 @@ function ObservationItem({
                   {observation.observerName.length > 12 ? "..." : ""}
                 </span>
               )}
+              <span
+                className="inline-flex items-center gap-1 px-2 py-0.5 bg-moss/20 text-bark dark:text-sand text-xs rounded-full"
+                title={`±${observation.uncertaintyRadius}m usikkerhet`}
+              >
+                <MapPin size={12} />±{observation.uncertaintyRadius}m
+              </span>
               {isExported && (
                 <div
-                  className="text-slate hover:text-bark transition-colors"
+                  className="ml-auto text-slate hover:text-bark transition-colors"
                   aria-label={isExpanded ? "Collapse" : "Expand"}
                 >
                   {isExpanded ? (
-                    <ChevronUp size={20} />
+                    <ChevronUp size={18} />
                   ) : (
-                    <ChevronDown size={20} />
+                    <ChevronDown size={18} />
                   )}
                 </div>
               )}
             </div>
-            <div className="flex items-center gap-sm text-sm text-slate mb-xs">
-              <MapPin size={16} />
-              <span>
-                {observation.location.lat.toFixed(4)},{" "}
-                {observation.location.lng.toFixed(4)} ±
-                {observation.uncertaintyRadius}m
-              </span>
-            </div>
-            <p className="text-sm text-slate">
-              {formatDateRange(observation.startDate, observation.endDate)}
+
+            {/* Coordinates with icon */}
+            <p className="flex items-center gap-1 font-mono text-xs text-bark/60">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="12"
+                height="12"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                className="text-slate/50"
+              >
+                <circle cx="12" cy="12" r="10" />
+                <path d="M12 2v20M2 12h20" />
+              </svg>
+              {observation.location.lat.toFixed(4)},{" "}
+              {observation.location.lng.toFixed(4)}
+            </p>
+
+            {/* Date */}
+            <p className="text-sm text-bark/70">
+              {observation.startDate
+                ? new Date(observation.startDate).toLocaleDateString("no-NO", {
+                    day: "2-digit",
+                    month: "2-digit",
+                    year: "numeric",
+                  })
+                : ""}
             </p>
             {isExported && observation.lastExportedAt && (
               <p className="text-xs text-slate mt-1">
@@ -144,28 +169,48 @@ function ObservationItem({
       {/* Collapsible content */}
       {isExpanded && (
         <div className="px-lg pb-lg space-y-sm">
-          <h3 className="font-semibold text-bark">Arter observert:</h3>
           {observation.species.map((speciesObs, idx) => (
-            <div key={idx} className="pl-md border-l-2 border-moss">
-              <div className="font-medium text-bark">
-                {speciesObs.species.PrefferedPopularname ??
-                  speciesObs.species.ValidScientificName}
-              </div>
-              <div className="text-sm text-slate">
-                {[
-                  speciesObs.count,
-                  speciesObs.gender,
-                  speciesObs.age,
-                  speciesObs.method,
-                  speciesObs.comment,
-                ]
-                  .filter(Boolean)
-                  .join(" • ")}
+            <div
+              key={idx}
+              className="bg-sand/50 dark:bg-bark/30 rounded-lg p-3 space-y-1"
+            >
+              <div className="flex items-center justify-between gap-2">
+                <span className="font-medium text-bark">
+                  {speciesObs.species.PrefferedPopularname ??
+                    speciesObs.species.ValidScientificName}
+                </span>
+                <div className="flex items-center gap-1 flex-wrap">
+                  {speciesObs.count && (
+                    <span className="text-xs bg-moss/20 text-bark dark:text-sand px-2 py-0.5 rounded-full">
+                      {speciesObs.count}
+                    </span>
+                  )}
+                  {speciesObs.gender && (
+                    <span className="text-xs bg-forest/20 text-bark dark:text-sand px-2 py-0.5 rounded-full">
+                      {speciesObs.gender}
+                    </span>
+                  )}
+                  {speciesObs.age && (
+                    <span className="text-xs bg-sand dark:bg-bark/50 text-bark dark:text-sand px-2 py-0.5 rounded-full border border-slate/20">
+                      {speciesObs.age}
+                    </span>
+                  )}
+                  {speciesObs.method && (
+                    <span className="text-xs bg-slate/20 text-bark dark:text-sand px-2 py-0.5 rounded-full">
+                      {speciesObs.method}
+                    </span>
+                  )}
+                  {speciesObs.activity && (
+                    <span className="text-xs bg-rust/20 text-bark dark:text-sand px-2 py-0.5 rounded-full">
+                      {speciesObs.activity}
+                    </span>
+                  )}
+                </div>
               </div>
               {speciesObs.comment && (
-                <div className="text-sm text-bark mt-1 italic">
-                  "{speciesObs.comment}"
-                </div>
+                <p className="text-sm text-bark/80 italic border-l-2 border-moss/30 pl-2 mt-1">
+                  {speciesObs.comment}
+                </p>
               )}
             </div>
           ))}

--- a/src/react-app/components/ObservationItem.tsx
+++ b/src/react-app/components/ObservationItem.tsx
@@ -71,6 +71,16 @@ function ObservationItem({
                 {observation.species.length}{" "}
                 {observation.species.length === 1 ? "art" : "arter"}
               </span>
+              {observation.observerName && (
+                <span
+                  className="inline-flex items-center gap-1 px-2 py-0.5 bg-forest/20 text-bark dark:text-sand text-xs rounded-full"
+                  title={observation.observerName}
+                >
+                  <User size={12} />
+                  {observation.observerName.slice(0, 12)}
+                  {observation.observerName.length > 12 ? "..." : ""}
+                </span>
+              )}
               {isExported && (
                 <div
                   className="text-slate hover:text-bark transition-colors"
@@ -95,15 +105,6 @@ function ObservationItem({
             <p className="text-sm text-slate">
               {formatDateRange(observation.startDate, observation.endDate)}
             </p>
-            {observation.observerName && (
-              <p className="text-sm text-slate flex items-center gap-1 mt-0.5">
-                <User size={13} />
-                <span className="text-bark/60 dark:text-sand/60">
-                  Medobservatør:
-                </span>
-                {observation.observerName}
-              </p>
-            )}
             {isExported && observation.lastExportedAt && (
               <p className="text-xs text-slate mt-1">
                 Sist eksportert: {formatDate(observation.lastExportedAt)}

--- a/src/react-app/components/ObservationItem.tsx
+++ b/src/react-app/components/ObservationItem.tsx
@@ -8,6 +8,7 @@ import {
   Trash2,
   MapPinned,
   User,
+  Bird,
 } from "lucide-react";
 import { Observation } from "../types/observation";
 import { Button } from "./ui/button";
@@ -53,7 +54,7 @@ function ObservationItem({
       >
         <div className="flex justify-between items-center">
           <div className="flex-1">
-            <div className="flex items-center gap-sm">
+            <div className="flex items-center gap-sm flex-wrap">
               {observation.locationName && (
                 <div className="font-medium text-bark flex items-center gap-1">
                   {observation.locationId && (
@@ -65,6 +66,11 @@ function ObservationItem({
                   {observation.locationName}
                 </div>
               )}
+              <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-moss/20 text-bark dark:text-sand text-xs rounded-full">
+                <Bird size={12} />
+                {observation.species.length}{" "}
+                {observation.species.length === 1 ? "art" : "arter"}
+              </span>
               {isExported && (
                 <div
                   className="text-slate hover:text-bark transition-colors"
@@ -92,6 +98,9 @@ function ObservationItem({
             {observation.observerName && (
               <p className="text-sm text-slate flex items-center gap-1 mt-0.5">
                 <User size={13} />
+                <span className="text-bark/60 dark:text-sand/60">
+                  Medobservatør:
+                </span>
                 {observation.observerName}
               </p>
             )}

--- a/src/react-app/components/StatsDashboard.tsx
+++ b/src/react-app/components/StatsDashboard.tsx
@@ -12,6 +12,7 @@ import {
   Plus,
   Search,
   TrendingUp,
+  Users,
 } from "lucide-react";
 import { useObservations } from "../context/ObservationsContext";
 import { useLocations } from "../context/LocationsContext";
@@ -73,6 +74,11 @@ interface LocationStat {
 
 interface MonthStat {
   label: string;
+  count: number;
+}
+
+interface MedobservatorStat {
+  name: string;
   count: number;
 }
 
@@ -151,6 +157,20 @@ function countUniqueSpecies(observations: Observation[]): number {
   return seen.size;
 }
 
+function computeMedobservatorStats(
+  observations: Observation[],
+): MedobservatorStat[] {
+  const map = new Map<string, number>();
+  for (const obs of observations) {
+    if (obs.observerName) {
+      map.set(obs.observerName, (map.get(obs.observerName) || 0) + 1);
+    }
+  }
+  return Array.from(map.entries())
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => b.count - a.count);
+}
+
 function countTotalIndividuals(observations: Observation[]): number {
   let total = 0;
   for (const obs of observations) {
@@ -223,6 +243,10 @@ export function StatsDashboard({ onBack }: StatsDashboardProps) {
   );
   const monthlyStats = useMemo(
     () => computeMonthlyStats(observations),
+    [observations],
+  );
+  const medobservatorStats = useMemo(
+    () => computeMedobservatorStats(observations),
     [observations],
   );
 
@@ -486,6 +510,37 @@ export function StatsDashboard({ onBack }: StatsDashboardProps) {
             </div>
           )}
         </div>
+
+        {/* Medobservatører */}
+        {medobservatorStats.length > 0 && (
+          <div className="bg-white dark:bg-[#2c2c2c] rounded-lg border-2 border-moss/30 p-md">
+            <h2 className="text-lg font-bold text-bark dark:text-sand mb-md flex items-center gap-sm">
+              <Users size={20} className="text-moss" />
+              Medobservatører
+            </h2>
+            <div className="space-y-sm">
+              {medobservatorStats.map((stat, i) => {
+                const maxCount = medobservatorStats[0].count;
+                return (
+                  <div key={i} className="flex items-center gap-sm">
+                    <div className="w-32 shrink-0 text-sm font-medium text-bark dark:text-sand truncate">
+                      {stat.name}
+                    </div>
+                    <div className="flex-1 bg-moss/10 dark:bg-moss/20 rounded-full h-5 overflow-hidden">
+                      <div
+                        className="bg-moss/70 dark:bg-moss/60 h-full rounded-full transition-all"
+                        style={{ width: `${(stat.count / maxCount) * 100}%` }}
+                      />
+                    </div>
+                    <div className="w-16 text-right text-sm text-bark/60 dark:text-sand/60 shrink-0">
+                      {stat.count} {stat.count === 1 ? "obs." : "obs."}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
 
         {/* Observations over time */}
         <div className="bg-white dark:bg-[#2c2c2c] rounded-lg border-2 border-moss/30 p-md">

--- a/src/react-app/components/UserProfile.tsx
+++ b/src/react-app/components/UserProfile.tsx
@@ -1,7 +1,16 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Button } from "./ui/button";
 import { useLocations } from "../context/LocationsContext";
-import { Download, Edit2, History, MapPin, Plus, Trash2 } from "lucide-react";
+import { useObservations } from "../context/ObservationsContext";
+import {
+  Download,
+  Edit2,
+  History,
+  MapPin,
+  Plus,
+  Trash2,
+  Binoculars,
+} from "lucide-react";
 import { UserLocation } from "../types/location";
 import { useDownloadExport, useExportLogs } from "../queries/useExports";
 import { isSupabaseConfigured } from "../lib/supabase";
@@ -14,6 +23,18 @@ interface UserProfileProps {
 
 export function UserProfile({ onBack }: UserProfileProps) {
   const { locations, deleteLocation } = useLocations();
+  const { observations } = useObservations();
+
+  // Count observations per location
+  const locationObservationCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const obs of observations) {
+      if (obs.locationId) {
+        counts.set(obs.locationId, (counts.get(obs.locationId) || 0) + 1);
+      }
+    }
+    return counts;
+  }, [observations]);
   const [showLocationForm, setShowLocationForm] = useState(false);
   const [editingLocation, setEditingLocation] = useState<UserLocation | null>(
     null,
@@ -124,6 +145,16 @@ export function UserProfile({ onBack }: UserProfileProps) {
                       {location.description && (
                         <p className="text-sm text-bark/80 dark:text-sand/80 mt-2">
                           {location.description}
+                        </p>
+                      )}
+                      {location.id && (
+                        <p className="text-sm text-bark/70 dark:text-sand/70 mt-2 flex items-center gap-1">
+                          <Binoculars size={14} className="text-moss" />
+                          {locationObservationCounts.get(location.id) || 0}{" "}
+                          {(locationObservationCounts.get(location.id) || 0) ===
+                          1
+                            ? "observasjon"
+                            : "observasjoner"}
                         </p>
                       )}
                     </div>

--- a/src/react-app/components/ui/Modal.tsx
+++ b/src/react-app/components/ui/Modal.tsx
@@ -100,6 +100,7 @@ export function Modal({
             {title}
           </h2>
           <Button
+            type="button"
             variant="ghost"
             size="icon"
             onClick={onClose}

--- a/src/react-app/lib/markerIcons.ts
+++ b/src/react-app/lib/markerIcons.ts
@@ -2,6 +2,36 @@ import L from "leaflet";
 import iconShadow from "leaflet/dist/images/marker-shadow.png";
 
 /**
+ * Extracts initials from a name.
+ * - If the name looks like initials already (1-3 uppercase letters, possibly separated by dots or spaces), returns the full name
+ * - Otherwise, takes the first letter of each word (John Doe → JD)
+ * - Limited to 2-3 characters max for display
+ */
+export function getInitials(name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed) return "";
+
+  // Check if it looks like initials already (e.g., "AB", "A.B.", "A B", "ABC")
+  const looksLikeInitials = /^[A-ZÆØÅ][.\s]?[A-ZÆØÅ]?[.\s]?[A-ZÆØÅ]?\.?$/.test(
+    trimmed,
+  );
+  if (looksLikeInitials && trimmed.length <= 5) {
+    // Return clean version without dots/spaces for display
+    return trimmed.replace(/[.\s]/g, "").toUpperCase().slice(0, 3);
+  }
+
+  // Take first letter of each word
+  const words = trimmed.split(/\s+/);
+  const initials = words
+    .map((word) => word[0]?.toUpperCase())
+    .filter(Boolean)
+    .join("");
+
+  // Limit to 2-3 characters
+  return initials.slice(0, 3);
+}
+
+/**
  * Creates a custom SVG marker icon with the specified color.
  * @param fillColor - The fill color for the marker
  * @param strokeColor - The stroke color for the marker
@@ -56,11 +86,57 @@ export const createSelectionIcon = () => {
 };
 
 /**
+ * Creates an SVG marker with initials text overlaid.
+ */
+const createMarkerSVGWithInitials = (
+  fillColor: string,
+  strokeColor: string,
+  initials: string,
+): string => {
+  const displayText = initials.slice(0, 3).toUpperCase();
+  const fontSize =
+    displayText.length === 1 ? 10 : displayText.length === 2 ? 9 : 7;
+  const yOffset = displayText.length <= 2 ? 13.5 : 14;
+
+  const svg = `
+    <svg width="25" height="41" viewBox="0 0 25 41" xmlns="http://www.w3.org/2000/svg">
+      <path d="M12.5 0C5.6 0 0 5.6 0 12.5c0 8.4 12.5 28.5 12.5 28.5S25 20.9 25 12.5C25 5.6 19.4 0 12.5 0z" 
+            fill="${fillColor}" stroke="${strokeColor}" stroke-width="1"/>
+      <circle cx="12.5" cy="12.5" r="4" fill="#FFF" opacity="0.3"/>
+      <text x="12.5" y="${yOffset}" 
+            font-family="system-ui, -apple-system, sans-serif" 
+            font-size="${fontSize}" 
+            font-weight="bold"
+            fill="white" 
+            text-anchor="middle"
+            dominant-baseline="middle">${displayText}</text>
+    </svg>
+  `;
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+};
+
+/**
  * Creates a Leaflet icon for observation markers.
  */
 export const createObservationIcon = () => {
   return L.icon({
     iconUrl: createForestGreenMarkerSVG(),
+    shadowUrl: iconShadow,
+    iconSize: [25, 41],
+    iconAnchor: [12, 41],
+    popupAnchor: [0, -41],
+  });
+};
+
+/**
+ * Creates a Leaflet icon for observation markers with initials.
+ */
+export const createObservationIconWithInitials = (
+  observerName: string | undefined,
+) => {
+  const initials = observerName ? getInitials(observerName) : "";
+  return L.icon({
+    iconUrl: createMarkerSVGWithInitials("#2F5D50", "#1a3d32", initials),
     shadowUrl: iconShadow,
     iconSize: [25, 41],
     iconAnchor: [12, 41],


### PR DESCRIPTION
Closes #142

## Summary
Renames the 'Observatør' field to 'Medobservatør' with full persistence and enhanced UI across the application.

## Changes
- **Form**: Field renamed to 'Medobservatør', moved to after dates
- **Persistence**: localStorage saves medobservatør across sessions
- **Statistics**: New dashboard section showing medobservatør activity
- **Map**: Initials on pins, badge above download button
- **List**: Inline badges (species count, medobservatør, uncertainty)
- **Card-style species**: All details as colored pills (count, gender, age, method, activity)
- **Excel export**: Column header renamed to 'Medobservatør'