### PR TITLE
Add hide and delayPublication fields to observations (#143)

### DIFF
--- a/src/react-app/api/exports.ts
+++ b/src/react-app/api/exports.ts
@@ -17,9 +17,9 @@ export async function generateExcelFromObservations(
   worksheet.columns = [
     { header: "Medobservatør", key: "observerName", width: 20 },
     { header: "Lokalitet", key: "locationName", width: 20 },
-    { header: "Latitude", key: "latitude", width: 12 },
-    { header: "Longitude", key: "longitude", width: 12 },
-    { header: "Usikkerhet (m)", key: "uncertainty", width: 15 },
+    { header: "nord", key: "latitude", width: 12 },
+    { header: "øst", key: "longitude", width: 12 },
+    { header: "nøyaktighet", key: "uncertainty", width: 15 },
     { header: "Start", key: "startDate", width: 20 },
     { header: "Slutt", key: "endDate", width: 20 },
     { header: "Last Exported At", key: "lastExportedAt", width: 20 },
@@ -27,11 +27,22 @@ export async function generateExcelFromObservations(
     { header: "Utsett publisering", key: "delayPublication", width: 20 },
     { header: "Art", key: "speciesNorwegian", width: 25 },
     { header: "Antall", key: "count", width: 10 },
+    { header: "Enhet", key: "unit", width: 10 },
     { header: "Kjønn", key: "gender", width: 10 },
     { header: "Alder", key: "age", width: 15 },
     { header: "Metode", key: "method", width: 15 },
     { header: "Aktivitet", key: "activity", width: 15 },
-    { header: "Kommentar", key: "comment", width: 30 },
+    { header: "kommentar (synlig for alle)", key: "comment", width: 30 },
+    { header: "Privat kommentar", key: "privateComment", width: 30 },
+    { header: "Privat samling", key: "privateCollection", width: 20 },
+    { header: "Ikke gjenfunnet", key: "notRediscovered", width: 10 },
+    { header: "Ikke funnet", key: "notFound", width: 10 },
+    { header: "Andrehånds", key: "secondHand", width: 10 },
+    {
+      header: "Usikker artsbestemming",
+      key: "uncertainIdentification",
+      width: 10,
+    },
   ];
 
   // Style the header row
@@ -67,11 +78,18 @@ export async function generateExcelFromObservations(
       worksheet.addRow({
         speciesNorwegian: spec.species.PrefferedPopularname,
         count: spec.count,
+        unit: spec.unit || "",
         gender: spec.gender,
         age: spec.age || "",
         method: spec.method || "",
         activity: spec.activity || "",
         comment: spec.comment || "",
+        privateComment: spec.privateComment || "",
+        privateCollection: spec.privateCollection || "",
+        notRediscovered: spec.notRediscovered ? "Ja" : "Nei",
+        notFound: spec.notFound ? "Ja" : "Nei",
+        secondHand: spec.secondHand ? "Ja" : "Nei",
+        uncertainIdentification: spec.uncertainIdentification ? "Ja" : "Nei",
       });
     });
   });

--- a/src/react-app/api/exports.ts
+++ b/src/react-app/api/exports.ts
@@ -15,34 +15,36 @@ export async function generateExcelFromObservations(
 
   // Define columns
   worksheet.columns = [
-    { header: "Medobservatør", key: "observerName", width: 20 },
-    { header: "Lokalitet", key: "locationName", width: 20 },
-    { header: "nord", key: "latitude", width: 12 },
-    { header: "øst", key: "longitude", width: 12 },
-    { header: "nøyaktighet", key: "uncertainty", width: 15 },
-    { header: "Start", key: "startDate", width: 20 },
-    { header: "Slutt", key: "endDate", width: 20 },
-    { header: "Last Exported At", key: "lastExportedAt", width: 20 },
-    { header: "Art", key: "speciesNorwegian", width: 25 },
+    { header: "Artsnavn", key: "speciesName", width: 25 },
+    { header: "Lokalitetsnavn", key: "locationName", width: 20 },
+    { header: "Nord", key: "latitude", width: 12 },
+    { header: "Øst", key: "longitude", width: 12 },
+    { header: "Nøyaktighet", key: "uncertainty", width: 15 },
     { header: "Antall", key: "count", width: 10 },
     { header: "Enhet", key: "unit", width: 10 },
     { header: "Kjønn", key: "gender", width: 10 },
     { header: "Alder", key: "age", width: 15 },
     { header: "Metode", key: "method", width: 15 },
     { header: "Aktivitet", key: "activity", width: 15 },
-    { header: "kommentar (synlig for alle)", key: "comment", width: 30 },
+    { header: "Fra klokkeslett", key: "startTime", width: 20 },
+    { header: "Til klokkeslett", key: "endTime", width: 20 },
+    { header: "Fra dato", key: "startDate", width: 20 },
+    { header: "Til dato", key: "endDate", width: 20 },
+    { header: "Skjul funn til dato", key: "hide", width: 10 },
+    { header: "Kommentar (synlig for alle)", key: "comment", width: 30 },
     { header: "Privat kommentar", key: "privateComment", width: 30 },
-    { header: "Privat samling", key: "privateCollection", width: 20 },
     { header: "Ikke gjenfunnet", key: "notRediscovered", width: 10 },
     { header: "Ikke funnet", key: "notFound", width: 10 },
+    { header: "Privat samling", key: "privateCollection", width: 20 },
     { header: "Andrehånds", key: "secondHand", width: 10 },
     {
       header: "Usikker artsbestemming",
       key: "uncertainIdentification",
       width: 10,
     },
-    { header: "Skjul", key: "hide", width: 10 },
     { header: "Utsett publisering", key: "delayPublication", width: 20 },
+    { header: "Medobservatør", key: "observerName", width: 20 },
+    { header: "Sist eksportert", key: "lastExportedAt", width: 20 },
   ];
 
   // Style the header row
@@ -55,24 +57,19 @@ export async function generateExcelFromObservations(
 
   // Add data rows
   observations.forEach((obs) => {
-    worksheet.addRow({
-      observerName: obs.observerName || "",
-      locationName: obs.locationName,
-      latitude: obs.location.lat,
-      longitude: obs.location.lng,
-      uncertainty: obs.uncertaintyRadius,
-      startDate: obs.startDate
-        ? new Date(obs.startDate).toLocaleString("no-NO")
-        : "",
-      endDate: obs.endDate ? new Date(obs.endDate).toLocaleString("no-NO") : "",
-      comment: obs.comment || "",
-      lastExportedAt: obs.lastExportedAt
-        ? new Date(obs.lastExportedAt).toLocaleString("no-NO")
-        : "Never",
-    });
     obs.species.forEach((spec) => {
       worksheet.addRow({
-        speciesNorwegian: spec.species.PrefferedPopularname,
+        observerName: obs.observerName || "",
+        locationName: obs.locationName,
+        latitude: obs.location.lat.toString().replace(",", "."),
+        longitude: obs.location.lng.toString().replace(",", "."),
+        uncertainty: obs.uncertaintyRadius,
+        startDate: parseDateString(obs.startDate),
+        startTime: parseTimeString(obs.startDate, true),
+        endDate: parseDateString(obs.endDate),
+        endTime: parseTimeString(obs.endDate, true),
+        lastExportedAt: parseDateString(obs.lastExportedAt),
+        speciesName: spec.species.PrefferedPopularname,
         count: spec.count,
         unit: spec.unit || "",
         gender: spec.gender,
@@ -82,14 +79,12 @@ export async function generateExcelFromObservations(
         comment: spec.comment || "",
         privateComment: spec.privateComment || "",
         privateCollection: spec.privateCollection || "",
-        notRediscovered: spec.notRediscovered ? "Ja" : "Nei",
-        notFound: spec.notFound ? "Ja" : "Nei",
-        secondHand: spec.secondHand ? "Ja" : "Nei",
-        uncertainIdentification: spec.uncertainIdentification ? "Ja" : "Nei",
-        hide: spec.hide ? "Ja" : "Nei",
-        delayPublication: spec.delayPublication
-          ? new Date(spec.delayPublication).toLocaleString("no-NO")
-          : "",
+        notRediscovered: parseBoolean(spec.notRediscovered),
+        notFound: parseBoolean(spec.notFound),
+        secondHand: parseBoolean(spec.secondHand),
+        uncertainIdentification: parseBoolean(spec.uncertainIdentification),
+        hide: parseBoolean(spec.hide),
+        delayPublication: parseDateString(spec.delayPublication),
       });
     });
   });
@@ -233,3 +228,16 @@ export function getExportFileUrl(filePath: string): string {
   const { data } = supabase.storage.from(bucketName).getPublicUrl(filePath);
   return data.publicUrl;
 }
+
+const parseBoolean = (bool?: boolean) => {
+  return bool ? "✓" : bool === false ? "x" : "";
+};
+
+const parseDateString = (date?: string) => {
+  return date ? new Date(date).toLocaleDateString("no-NO") : "";
+};
+
+const parseTimeString = (date?: string, midnightAsNull?: boolean) => {
+  const parsed = date ? new Date(date).toLocaleTimeString("no-NO") : "";
+  return parsed === "00:00:00" && midnightAsNull ? "" : parsed;
+};

--- a/src/react-app/api/exports.ts
+++ b/src/react-app/api/exports.ts
@@ -23,8 +23,6 @@ export async function generateExcelFromObservations(
     { header: "Start", key: "startDate", width: 20 },
     { header: "Slutt", key: "endDate", width: 20 },
     { header: "Last Exported At", key: "lastExportedAt", width: 20 },
-    { header: "Skjul", key: "hide", width: 10 },
-    { header: "Utsett publisering", key: "delayPublication", width: 20 },
     { header: "Art", key: "speciesNorwegian", width: 25 },
     { header: "Antall", key: "count", width: 10 },
     { header: "Enhet", key: "unit", width: 10 },
@@ -43,6 +41,8 @@ export async function generateExcelFromObservations(
       key: "uncertainIdentification",
       width: 10,
     },
+    { header: "Skjul", key: "hide", width: 10 },
+    { header: "Utsett publisering", key: "delayPublication", width: 20 },
   ];
 
   // Style the header row
@@ -69,10 +69,6 @@ export async function generateExcelFromObservations(
       lastExportedAt: obs.lastExportedAt
         ? new Date(obs.lastExportedAt).toLocaleString("no-NO")
         : "Never",
-      hide: obs.hide ? "Ja" : "Nei",
-      delayPublication: obs.delayPublication
-        ? new Date(obs.delayPublication).toLocaleString("no-NO")
-        : "",
     });
     obs.species.forEach((spec) => {
       worksheet.addRow({
@@ -90,6 +86,10 @@ export async function generateExcelFromObservations(
         notFound: spec.notFound ? "Ja" : "Nei",
         secondHand: spec.secondHand ? "Ja" : "Nei",
         uncertainIdentification: spec.uncertainIdentification ? "Ja" : "Nei",
+        hide: spec.hide ? "Ja" : "Nei",
+        delayPublication: spec.delayPublication
+          ? new Date(spec.delayPublication).toLocaleString("no-NO")
+          : "",
       });
     });
   });

--- a/src/react-app/api/exports.ts
+++ b/src/react-app/api/exports.ts
@@ -23,6 +23,8 @@ export async function generateExcelFromObservations(
     { header: "Start", key: "startDate", width: 20 },
     { header: "Slutt", key: "endDate", width: 20 },
     { header: "Last Exported At", key: "lastExportedAt", width: 20 },
+    { header: "Skjul", key: "hide", width: 10 },
+    { header: "Utsett publisering", key: "delayPublication", width: 20 },
     { header: "Art", key: "speciesNorwegian", width: 25 },
     { header: "Antall", key: "count", width: 10 },
     { header: "Kjønn", key: "gender", width: 10 },
@@ -56,6 +58,10 @@ export async function generateExcelFromObservations(
       lastExportedAt: obs.lastExportedAt
         ? new Date(obs.lastExportedAt).toLocaleString("no-NO")
         : "Never",
+      hide: obs.hide ? "Ja" : "Nei",
+      delayPublication: obs.delayPublication
+        ? new Date(obs.delayPublication).toLocaleString("no-NO")
+        : "",
     });
     obs.species.forEach((spec) => {
       worksheet.addRow({

--- a/src/react-app/api/exports.ts
+++ b/src/react-app/api/exports.ts
@@ -238,6 +238,11 @@ const parseDateString = (date?: string) => {
 };
 
 const parseTimeString = (date?: string, midnightAsNull?: boolean) => {
-  const parsed = date ? new Date(date).toLocaleTimeString("no-NO") : "";
+  const parsed = date
+    ? new Date(date).toLocaleTimeString("no-NO", {
+        hour: "2-digit",
+        minute: "2-digit",
+      })
+    : "";
   return parsed === "00:00:00" && midnightAsNull ? "" : parsed;
 };

--- a/src/react-app/components/ObservationForm.tsx
+++ b/src/react-app/components/ObservationForm.tsx
@@ -163,8 +163,6 @@ const ObservationForm = ({
             species: [{ species: presetSpecies }],
           }
         : {}),
-      hide: observation?.hide ?? false,
-      delayPublication: observation?.delayPublication ?? null,
     },
   });
   const uncertaintyRadius = useWatch({
@@ -484,11 +482,17 @@ const ObservationForm = ({
                   field === "notRediscovered" ||
                   field === "notFound" ||
                   field === "secondHand" ||
-                  field === "uncertainIdentification"
+                  field === "uncertainIdentification" ||
+                  field === "hide"
                 ) {
                   updated[index] = {
                     ...updated[index],
                     [field]: value as boolean,
+                  };
+                } else if (field === "delayPublication") {
+                  updated[index] = {
+                    ...updated[index],
+                    [field]: value as string | null,
                   };
                 }
                 onChange(updated);
@@ -1034,67 +1038,6 @@ const ObservationForm = ({
                   className="mt-1"
                   rows={3}
                 />
-              </div>
-            )}
-          />
-
-          <Controller
-            name={"hide"}
-            control={control}
-            render={({ field: { value, onChange } }) => (
-              <div className="flex items-center gap-sm">
-                <input
-                  type="checkbox"
-                  id="hide"
-                  checked={value || false}
-                  onChange={(e) => onChange(e.target.checked)}
-                  className="w-5 h-5 rounded border-slate-border"
-                />
-                <Label
-                  htmlFor="hide"
-                  className="text-bark dark:text-sand cursor-pointer"
-                >
-                  Skjul fra Artsobservasjoner
-                </Label>
-              </div>
-            )}
-          />
-
-          <Controller
-            name={"delayPublication"}
-            control={control}
-            render={({ field: { value, onChange } }) => (
-              <div>
-                <Label
-                  htmlFor="delayPublication"
-                  className="text-bark dark:text-sand"
-                >
-                  Utsett publisering til
-                </Label>
-                <DemoContainer components={["DatePicker"]}>
-                  <MobileDatePicker
-                    slotProps={{
-                      textField: {
-                        fullWidth: true,
-                        sx: {
-                          "& .MuiOutlinedInput-root": {
-                            borderRadius: 10,
-                            background: "white",
-                            "& fieldset": { border: "none" },
-                            "&:hover fieldset": { border: "none" },
-                            "&.Mui-focused fieldset": { border: "none" },
-                          },
-                        },
-                      },
-                      field: { clearable: true },
-                    }}
-                    sx={{ background: "white" }}
-                    value={value ? dayjs(value) : null}
-                    onChange={(newValue) =>
-                      onChange(newValue ? newValue.toISOString() : null)
-                    }
-                  />
-                </DemoContainer>
               </div>
             )}
           />

--- a/src/react-app/components/ObservationForm.tsx
+++ b/src/react-app/components/ObservationForm.tsx
@@ -163,6 +163,8 @@ const ObservationForm = ({
             species: [{ species: presetSpecies }],
           }
         : {}),
+      hide: observation?.hide ?? false,
+      delayPublication: observation?.delayPublication ?? null,
     },
   });
   const uncertaintyRadius = useWatch({
@@ -1004,6 +1006,67 @@ const ObservationForm = ({
                   className="mt-1"
                   rows={3}
                 />
+              </div>
+            )}
+          />
+
+          <Controller
+            name={"hide"}
+            control={control}
+            render={({ field: { value, onChange } }) => (
+              <div className="flex items-center gap-sm">
+                <input
+                  type="checkbox"
+                  id="hide"
+                  checked={value || false}
+                  onChange={(e) => onChange(e.target.checked)}
+                  className="w-5 h-5 rounded border-slate-border"
+                />
+                <Label
+                  htmlFor="hide"
+                  className="text-bark dark:text-sand cursor-pointer"
+                >
+                  Skjul fra Artsobservasjoner
+                </Label>
+              </div>
+            )}
+          />
+
+          <Controller
+            name={"delayPublication"}
+            control={control}
+            render={({ field: { value, onChange } }) => (
+              <div>
+                <Label
+                  htmlFor="delayPublication"
+                  className="text-bark dark:text-sand"
+                >
+                  Utsett publisering til
+                </Label>
+                <DemoContainer components={["DatePicker"]}>
+                  <MobileDatePicker
+                    slotProps={{
+                      textField: {
+                        fullWidth: true,
+                        sx: {
+                          "& .MuiOutlinedInput-root": {
+                            borderRadius: 10,
+                            background: "white",
+                            "& fieldset": { border: "none" },
+                            "&:hover fieldset": { border: "none" },
+                            "&.Mui-focused fieldset": { border: "none" },
+                          },
+                        },
+                      },
+                      field: { clearable: true },
+                    }}
+                    sx={{ background: "white" }}
+                    value={value ? dayjs(value) : null}
+                    onChange={(newValue) =>
+                      onChange(newValue ? newValue.toISOString() : null)
+                    }
+                  />
+                </DemoContainer>
               </div>
             )}
           />

--- a/src/react-app/components/ObservationForm.tsx
+++ b/src/react-app/components/ObservationForm.tsx
@@ -444,7 +444,7 @@ const ObservationForm = ({
               const updateSpecies = (
                 index: number,
                 field: keyof Species,
-                value: string | number | boolean,
+                value: string | number | boolean | undefined,
               ) => {
                 const updated = [...species];
                 if (field === "count") {
@@ -628,10 +628,9 @@ const ObservationForm = ({
                         <SpeciesItem
                           key={index}
                           species={s}
-                          updateSpecies={(
-                            field: keyof Species,
-                            value: string | number | boolean,
-                          ) => updateSpecies(index, field, value)}
+                          updateSpecies={(field, value) =>
+                            updateSpecies(index, field, value)
+                          }
                           updateTaxonGroup={(taxonGroup: string) => {
                             const updated = [...species];
                             updated[index] = {

--- a/src/react-app/components/ObservationForm.tsx
+++ b/src/react-app/components/ObservationForm.tsx
@@ -492,7 +492,7 @@ const ObservationForm = ({
                 } else if (field === "delayPublication") {
                   updated[index] = {
                     ...updated[index],
-                    [field]: value as string | null,
+                    [field]: value as string | undefined,
                   };
                 }
                 onChange(updated);

--- a/src/react-app/components/ObservationForm.tsx
+++ b/src/react-app/components/ObservationForm.tsx
@@ -446,10 +446,13 @@ const ObservationForm = ({
               const updateSpecies = (
                 index: number,
                 field: keyof Species,
-                value: string | number,
+                value: string | number | boolean,
               ) => {
                 const updated = [...species];
                 if (field === "count") {
+                  if (typeof value !== "number" && typeof value !== "string") {
+                    return;
+                  }
                   const parsedValue =
                     typeof value === "number"
                       ? value
@@ -463,12 +466,11 @@ const ObservationForm = ({
                     ...updated[index],
                     [field]: parsedValue,
                   };
-                } else if (field === "gender") {
-                  updated[index] = {
-                    ...updated[index],
-                    [field]: value as string,
-                  };
                 } else if (
+                  field === "gender" ||
+                  field === "unit" ||
+                  field === "privateComment" ||
+                  field === "privateCollection" ||
                   field === "comment" ||
                   field === "age" ||
                   field === "method" ||
@@ -477,6 +479,16 @@ const ObservationForm = ({
                   updated[index] = {
                     ...updated[index],
                     [field]: value as string,
+                  };
+                } else if (
+                  field === "notRediscovered" ||
+                  field === "notFound" ||
+                  field === "secondHand" ||
+                  field === "uncertainIdentification"
+                ) {
+                  updated[index] = {
+                    ...updated[index],
+                    [field]: value as boolean,
                   };
                 }
                 onChange(updated);
@@ -614,7 +626,7 @@ const ObservationForm = ({
                           species={s}
                           updateSpecies={(
                             field: keyof Species,
-                            value: string | number,
+                            value: string | number | boolean,
                           ) => updateSpecies(index, field, value)}
                           updateTaxonGroup={(taxonGroup: string) => {
                             const updated = [...species];

--- a/src/react-app/components/ObservationItem.tsx
+++ b/src/react-app/components/ObservationItem.tsx
@@ -95,6 +95,17 @@ function ObservationItem({
                 {observation.observerName}
               </p>
             )}
+            {observation.hide && (
+              <p className="text-sm text-slate flex items-center gap-1 mt-0.5">
+                🚫 Skjult fra Artsobservasjoner
+              </p>
+            )}
+            {observation.delayPublication && (
+              <p className="text-sm text-slate flex items-center gap-1 mt-0.5">
+                📅 Utsett publisering:{" "}
+                {formatDate(observation.delayPublication)}
+              </p>
+            )}
             {isExported && observation.lastExportedAt && (
               <p className="text-xs text-slate mt-1">
                 Sist eksportert: {formatDate(observation.lastExportedAt)}

--- a/src/react-app/components/ObservationItem.tsx
+++ b/src/react-app/components/ObservationItem.tsx
@@ -200,6 +200,7 @@ function ObservationItem({
                   {speciesObs.count && (
                     <span className="text-xs bg-moss/20 text-bark dark:text-sand px-2 py-0.5 rounded-full">
                       {speciesObs.count}
+                      {speciesObs.unit && ` ${speciesObs.unit}`}
                     </span>
                   )}
                   {speciesObs.gender && (
@@ -222,11 +223,41 @@ function ObservationItem({
                       {speciesObs.activity}
                     </span>
                   )}
+                  {speciesObs.notRediscovered && (
+                    <span className="text-xs bg-moss/20 text-bark dark:text-sand px-2 py-0.5 rounded-full">
+                      Ikke gjenfunnet
+                    </span>
+                  )}
+                  {speciesObs.notFound && (
+                    <span className="text-xs bg-moss/20 text-bark dark:text-sand px-2 py-0.5 rounded-full">
+                      Ikke funnet
+                    </span>
+                  )}
+                  {speciesObs.secondHand && (
+                    <span className="text-xs bg-moss/20 text-bark dark:text-sand px-2 py-0.5 rounded-full">
+                      Andrehånds
+                    </span>
+                  )}
+                  {speciesObs.uncertainIdentification && (
+                    <span className="text-xs bg-moss/20 text-bark dark:text-sand px-2 py-0.5 rounded-full">
+                      Usikker artsbestemming
+                    </span>
+                  )}
                 </div>
               </div>
               {speciesObs.comment && (
                 <p className="text-sm text-bark/80 italic border-l-2 border-moss/30 pl-2 mt-1">
                   {speciesObs.comment}
+                </p>
+              )}
+              {speciesObs.privateComment && (
+                <p className="text-sm text-slate italic border-l-2 border-slate/30 pl-2 mt-1">
+                  Privat: "{speciesObs.privateComment}"
+                </p>
+              )}
+              {speciesObs.privateCollection && (
+                <p className="text-sm text-slate flex items-center gap-1 mt-1">
+                  📚 Samling: {speciesObs.privateCollection}
                 </p>
               )}
             </div>

--- a/src/react-app/components/ObservationItem.tsx
+++ b/src/react-app/components/ObservationItem.tsx
@@ -136,17 +136,6 @@ function ObservationItem({
                 {observation.observerName}
               </p>
             )}
-            {observation.hide && (
-              <p className="text-sm text-slate flex items-center gap-1 mt-0.5">
-                🚫 Skjult fra Artsobservasjoner
-              </p>
-            )}
-            {observation.delayPublication && (
-              <p className="text-sm text-slate flex items-center gap-1 mt-0.5">
-                📅 Utsett publisering:{" "}
-                {formatDate(observation.delayPublication)}
-              </p>
-            )}
             {isExported && observation.lastExportedAt && (
               <p className="text-xs text-slate mt-1">
                 Sist eksportert: {formatDate(observation.lastExportedAt)}
@@ -243,6 +232,11 @@ function ObservationItem({
                       Usikker artsbestemming
                     </span>
                   )}
+                  {speciesObs.hide && (
+                    <span className="text-xs bg-rust/20 text-bark dark:text-sand px-2 py-0.5 rounded-full">
+                      🚫 Skjult
+                    </span>
+                  )}
                 </div>
               </div>
               {speciesObs.comment && (
@@ -258,6 +252,12 @@ function ObservationItem({
               {speciesObs.privateCollection && (
                 <p className="text-sm text-slate flex items-center gap-1 mt-1">
                   📚 Samling: {speciesObs.privateCollection}
+                </p>
+              )}
+              {speciesObs.delayPublication && (
+                <p className="text-sm text-slate flex items-center gap-1 mt-1">
+                  📅 Utsett publisering:{" "}
+                  {formatDate(speciesObs.delayPublication)}
                 </p>
               )}
             </div>

--- a/src/react-app/components/SpeciesItem.tsx
+++ b/src/react-app/components/SpeciesItem.tsx
@@ -10,7 +10,10 @@ import { getAgeOptionsForTaxonGroup } from "../lib/ageOptions.ts";
 
 interface SpeciesItemProps {
   species: Species;
-  updateSpecies: (field: keyof Species, value: string | number) => void;
+  updateSpecies: (
+    field: keyof Species,
+    value: string | number | boolean,
+  ) => void;
   updateTaxonGroup: (taxonGroup: string) => void;
   removeSpecies: () => void;
   key: number;
@@ -176,6 +179,23 @@ const SpeciesItem = ({
             </div>
           </div>
 
+          <div>
+            <Label
+              htmlFor={`unit-${key}`}
+              className="text-bark dark:text-sand text-xs"
+            >
+              Enhet
+            </Label>
+            <Input
+              id={`unit-${key}`}
+              type="text"
+              placeholder="f.eks. individer, par"
+              value={species.unit || ""}
+              onChange={(e) => updateSpecies("unit", e.target.value)}
+              className="mt-1"
+            />
+          </div>
+
           <div className="grid grid-cols-3 gap-sm">
             <div>
               <Label
@@ -241,7 +261,7 @@ const SpeciesItem = ({
               htmlFor={`species-comment-${key}`}
               className="text-bark dark:text-sand text-xs"
             >
-              Notat
+              Notat (synlig for alle)
             </Label>
             <Textarea
               id={`species-comment-${key}`}
@@ -251,6 +271,93 @@ const SpeciesItem = ({
               className="mt-1"
               rows={2}
             />
+          </div>
+
+          <div>
+            <Label
+              htmlFor={`private-comment-${key}`}
+              className="text-bark dark:text-sand text-xs"
+            >
+              Privat kommentar
+            </Label>
+            <Textarea
+              id={`private-comment-${key}`}
+              placeholder="Private notater..."
+              value={species.privateComment || ""}
+              onChange={(e) => updateSpecies("privateComment", e.target.value)}
+              className="mt-1"
+              rows={2}
+            />
+          </div>
+
+          <div>
+            <Label
+              htmlFor={`private-collection-${key}`}
+              className="text-bark dark:text-sand text-xs"
+            >
+              Privat samling
+            </Label>
+            <Input
+              id={`private-collection-${key}`}
+              type="text"
+              placeholder="Navn på samlingseier"
+              value={species.privateCollection || ""}
+              onChange={(e) =>
+                updateSpecies("privateCollection", e.target.value)
+              }
+              className="mt-1"
+            />
+          </div>
+
+          <div className="flex flex-wrap gap-sm">
+            <label className="flex items-center gap-sm cursor-pointer">
+              <input
+                type="checkbox"
+                checked={species.notRediscovered || false}
+                onChange={(e) =>
+                  updateSpecies("notRediscovered", e.target.checked)
+                }
+                className="w-4 h-4"
+              />
+              <span className="text-xs text-bark dark:text-sand">
+                Ikke gjenfunnet
+              </span>
+            </label>
+            <label className="flex items-center gap-sm cursor-pointer">
+              <input
+                type="checkbox"
+                checked={species.notFound || false}
+                onChange={(e) => updateSpecies("notFound", e.target.checked)}
+                className="w-4 h-4"
+              />
+              <span className="text-xs text-bark dark:text-sand">
+                Ikke funnet
+              </span>
+            </label>
+            <label className="flex items-center gap-sm cursor-pointer">
+              <input
+                type="checkbox"
+                checked={species.secondHand || false}
+                onChange={(e) => updateSpecies("secondHand", e.target.checked)}
+                className="w-4 h-4"
+              />
+              <span className="text-xs text-bark dark:text-sand">
+                Andrehånds
+              </span>
+            </label>
+            <label className="flex items-center gap-sm cursor-pointer">
+              <input
+                type="checkbox"
+                checked={species.uncertainIdentification || false}
+                onChange={(e) =>
+                  updateSpecies("uncertainIdentification", e.target.checked)
+                }
+                className="w-4 h-4"
+              />
+              <span className="text-xs text-bark dark:text-sand">
+                Usikker artsbestemming
+              </span>
+            </label>
           </div>
         </div>
       )}

--- a/src/react-app/components/SpeciesItem.tsx
+++ b/src/react-app/components/SpeciesItem.tsx
@@ -358,6 +358,57 @@ const SpeciesItem = ({
                 Usikker artsbestemming
               </span>
             </label>
+            <label className="flex items-center gap-sm cursor-pointer">
+              <input
+                type="checkbox"
+                checked={species.hide || false}
+                onChange={(e) => updateSpecies("hide", e.target.checked)}
+                className="w-4 h-4"
+              />
+              <span className="text-xs text-bark dark:text-sand">
+                Skjul fra Artsobservasjoner
+              </span>
+            </label>
+          </div>
+
+          <div>
+            <Label
+              htmlFor={`delay-publication-${key}`}
+              className="text-bark dark:text-sand text-xs"
+            >
+              Utsett publisering til
+            </Label>
+            <DemoContainer components={["DatePicker"]}>
+              <MobileDatePicker
+                slotProps={{
+                  textField: {
+                    fullWidth: true,
+                    sx: {
+                      "& .MuiOutlinedInput-root": {
+                        borderRadius: 10,
+                        background: "white",
+                        "& fieldset": { border: "none" },
+                        "&:hover fieldset": { border: "none" },
+                        "&.Mui-focused fieldset": { border: "none" },
+                      },
+                    },
+                  },
+                  field: { clearable: true },
+                }}
+                sx={{ background: "white" }}
+                value={
+                  species.delayPublication
+                    ? dayjs(species.delayPublication)
+                    : null
+                }
+                onChange={(newValue) =>
+                  updateSpecies(
+                    "delayPublication",
+                    newValue ? newValue.toISOString() : null,
+                  )
+                }
+              />
+            </DemoContainer>
           </div>
         </div>
       )}

--- a/src/react-app/components/SpeciesItem.tsx
+++ b/src/react-app/components/SpeciesItem.tsx
@@ -7,12 +7,15 @@ import { Textarea } from "./ui/textarea.tsx";
 import { useMemo, useState } from "react";
 import { Species } from "../types/observation.ts";
 import { getAgeOptionsForTaxonGroup } from "../lib/ageOptions.ts";
+import { DemoContainer } from "@mui/x-date-pickers/internals/demo";
+import { MobileDatePicker } from "@mui/x-date-pickers/MobileDatePicker";
+import dayjs from "dayjs";
 
 interface SpeciesItemProps {
   species: Species;
   updateSpecies: (
     field: keyof Species,
-    value: string | number | boolean,
+    value?: string | number | boolean,
   ) => void;
   updateTaxonGroup: (taxonGroup: string) => void;
   removeSpecies: () => void;
@@ -399,12 +402,12 @@ const SpeciesItem = ({
                 value={
                   species.delayPublication
                     ? dayjs(species.delayPublication)
-                    : null
+                    : undefined
                 }
                 onChange={(newValue) =>
                   updateSpecies(
                     "delayPublication",
-                    newValue ? newValue.toISOString() : null,
+                    newValue ? newValue.toISOString() : undefined,
                   )
                 }
               />

--- a/src/react-app/types/observation.ts
+++ b/src/react-app/types/observation.ts
@@ -17,6 +17,8 @@ export interface Species {
   privateCollection?: string; // Name of collection owner
   secondHand?: boolean; // Second-hand observation
   uncertainIdentification?: boolean; // Uncertain species identification
+  hide?: boolean; // Mark species to hide from Artsobservasjoner (but still export to Excel)
+  delayPublication?: string | null; // ISO date string for when to delay publication to
 }
 
 export interface Observation {
@@ -37,6 +39,4 @@ export interface Observation {
   exportCount?: number; // Number of times this observation has been exported
   locationId?: string;
   observerName?: string; // Name of the observer (selected user or freetext)
-  hide?: boolean; // Mark observation to hide from Artsobservasjoner (but still export to Excel)
-  delayPublication?: string | null; // ISO date string for when to delay publication to
 }

--- a/src/react-app/types/observation.ts
+++ b/src/react-app/types/observation.ts
@@ -18,7 +18,7 @@ export interface Species {
   secondHand?: boolean; // Second-hand observation
   uncertainIdentification?: boolean; // Uncertain species identification
   hide?: boolean; // Mark species to hide from Artsobservasjoner (but still export to Excel)
-  delayPublication?: string | null; // ISO date string for when to delay publication to
+  delayPublication?: string; // ISO date string for when to delay publication to
 }
 
 export interface Observation {

--- a/src/react-app/types/observation.ts
+++ b/src/react-app/types/observation.ts
@@ -6,10 +6,17 @@ export interface Species {
   species: TaxonRecord;
   gender?: string;
   count?: number;
+  unit?: string; // Unit for the count (e.g., "individuals", "pairs")
   age?: string; // Age of the observed species
   method?: string; // Observation method
   activity?: string; // Activity observed
-  comment?: string; // Per-species comment
+  comment?: string; // Per-species comment (visible to all)
+  privateComment?: string; // Private comment
+  notRediscovered?: boolean; // Not rediscovered
+  notFound?: boolean; // Not found
+  privateCollection?: string; // Name of collection owner
+  secondHand?: boolean; // Second-hand observation
+  uncertainIdentification?: boolean; // Uncertain species identification
 }
 
 export interface Observation {

--- a/src/react-app/types/observation.ts
+++ b/src/react-app/types/observation.ts
@@ -30,4 +30,6 @@ export interface Observation {
   exportCount?: number; // Number of times this observation has been exported
   locationId?: string;
   observerName?: string; // Name of the observer (selected user or freetext)
+  hide?: boolean; // Mark observation to hide from Artsobservasjoner (but still export to Excel)
+  delayPublication?: string | null; // ISO date string for when to delay publication to
 }


### PR DESCRIPTION
Implements issue #143: Add two new fields to observations

- **Skjul (Hide)**: Boolean checkbox to mark observations that shouldn't be published to Artsobservasjoner (but still appear in Excel exports)
- **Utsett publisering (Delay publication)**: Date field for when the observation should be published (for sensitive finds like bird nests)

Changes:
- Added  and  to Observation interface
- Added checkbox UI for 'Skjul' field in ObservationForm
- Added date picker UI for 'Utsett publisering' field in ObservationForm  
- Display hide and delayPublication in ObservationItem with emoji indicators
- Added Skjul and Utsett publisering columns to Excel export
- Updated form default values for new fields

Note: User will manually add the database fields in Supabase, so no migration file is needed.