### PR TITLE
Add editable table view to /observations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@tanstack/query-sync-storage-persister": "^5.100.13",
         "@tanstack/react-query": "^5.90.20",
         "@tanstack/react-query-persist-client": "^5.100.13",
+        "@tanstack/react-table": "^8.21.3",
         "@types/leaflet": "^1.9.12",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -4803,6 +4804,39 @@
       "peerDependencies": {
         "@tanstack/react-query": "^5.100.13",
         "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
+      "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/table-core": "8.21.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@trickfilm400/rollup-plugin-off-main-thread": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@tanstack/query-sync-storage-persister": "^5.100.13",
     "@tanstack/react-query": "^5.90.20",
     "@tanstack/react-query-persist-client": "^5.100.13",
+    "@tanstack/react-table": "^8.21.3",
     "@types/leaflet": "^1.9.12",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/react-app/components/Header.tsx
+++ b/src/react-app/components/Header.tsx
@@ -16,7 +16,7 @@ const Header = ({
   navButtons,
 }: HeaderProps) => {
   return (
-    <header className="bg-forest text-sand p-md sticky top-0 z-100">
+    <header className="bg-forest text-sand p-md sticky top-0 z-[1200]">
       <div className="max-w-4xl mx-auto ml-16">
         <h1 className="text-sand m-0 text-[clamp(2rem,6vw,3rem)] tracking-wider">
           {title}

--- a/src/react-app/components/MyObservations.tsx
+++ b/src/react-app/components/MyObservations.tsx
@@ -1,13 +1,15 @@
 import { useState } from "react";
-import { FileSpreadsheet, Filter, MapPin } from "lucide-react";
+import { FileSpreadsheet, Filter, LayoutList, MapPin, Table2 } from "lucide-react";
 import { useObservations } from "../context/ObservationsContext";
 import { useLocations } from "../context/LocationsContext";
 import { Button } from "./ui/button";
 import ObservationForm from "./ObservationForm.tsx";
 import ExportDialog from "./ExportDialog";
 import ObservationItem from "./ObservationItem";
+import ObservationsTable from "./ObservationsTable.tsx";
 import { getUnexportedCount } from "../queries/useExports";
 import Header from "./Header.tsx";
+import { twMerge } from "tailwind-merge";
 
 interface MyObservationsProps {
   onBack: () => void;
@@ -19,6 +21,7 @@ function MyObservations({ onBack }: MyObservationsProps) {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [showExportDialog, setShowExportDialog] = useState(false);
   const [filterLocationId, setFilterLocationId] = useState<string | null>(null);
+  const [view, setView] = useState<"list" | "table">("list");
 
   const formatDate = (dateString: string) => {
     const date = new Date(dateString);
@@ -84,7 +87,12 @@ function MyObservations({ onBack }: MyObservationsProps) {
   return (
     <div className="w-full min-h-screen bg-sand dark:bg-bark pb-16 md:pb-0">
       <Header title={"kikket på"} />
-      <div className="max-w-4xl mx-auto p-lg md:p-xl">
+      <div
+        className={twMerge(
+          "mx-auto p-lg md:p-xl",
+          view === "table" ? "max-w-full" : "max-w-4xl",
+        )}
+      >
         <div className="mb-lg flex flex-col md:flex-row justify-between items-start md:items-center gap-md">
           <div className="hidden md:block">
             <Button onClick={onBack} variant="outline">
@@ -111,20 +119,52 @@ function MyObservations({ onBack }: MyObservationsProps) {
             </div>
           )}
 
-          {observations.length > 0 && (
-            <Button
-              onClick={() => setShowExportDialog(true)}
-              className="ml-auto"
-            >
-              <FileSpreadsheet size={20} className="mr-2" />
-              Eksporter til Excel
-              {unexportedCount > 0 && (
-                <span className="ml-2 px-2 py-0.5 bg-moss text-white text-xs rounded-full">
-                  {unexportedCount} nye
-                </span>
-              )}
-            </Button>
-          )}
+          <div className="flex items-center gap-2 ml-auto">
+            <div className="flex items-center border-2 border-moss rounded-md overflow-hidden">
+              <button
+                type="button"
+                onClick={() => setView("list")}
+                aria-pressed={view === "list"}
+                className={twMerge(
+                  "p-2 transition-colors",
+                  view === "list"
+                    ? "bg-moss text-white"
+                    : "bg-white dark:bg-bark text-bark dark:text-sand hover:bg-sand dark:hover:bg-forest",
+                )}
+                aria-label="Listevisning"
+                title="Listevisning"
+              >
+                <LayoutList size={18} />
+              </button>
+              <button
+                type="button"
+                onClick={() => setView("table")}
+                aria-pressed={view === "table"}
+                className={twMerge(
+                  "p-2 transition-colors",
+                  view === "table"
+                    ? "bg-moss text-white"
+                    : "bg-white dark:bg-bark text-bark dark:text-sand hover:bg-sand dark:hover:bg-forest",
+                )}
+                aria-label="Tabellvisning"
+                title="Tabellvisning"
+              >
+                <Table2 size={18} />
+              </button>
+            </div>
+
+            {observations.length > 0 && (
+              <Button onClick={() => setShowExportDialog(true)}>
+                <FileSpreadsheet size={20} className="mr-2" />
+                Eksporter til Excel
+                {unexportedCount > 0 && (
+                  <span className="ml-2 px-2 py-0.5 bg-moss text-white text-xs rounded-full">
+                    {unexportedCount} nye
+                  </span>
+                )}
+              </Button>
+            )}
+          </div>
         </div>
 
         {filteredObservations.length === 0 && observations.length > 0 ? (
@@ -145,6 +185,8 @@ function MyObservations({ onBack }: MyObservationsProps) {
               Klikk på kartet for å legge til din første observasjon!
             </p>
           </div>
+        ) : view === "table" ? (
+          <ObservationsTable observations={filteredObservations} />
         ) : (
           <div className="flex flex-col space-y-md">
             {filteredObservations.map((observation) => (

--- a/src/react-app/components/MyObservations.tsx
+++ b/src/react-app/components/MyObservations.tsx
@@ -9,10 +9,12 @@ import {
   Table2,
   X,
 } from "lucide-react";
+import dayjs, { Dayjs } from "dayjs";
 import { useObservations } from "../context/ObservationsContext";
 import { useLocations } from "../context/LocationsContext";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input.tsx";
+import { DatePicker } from "./ui/date-picker.tsx";
 import ObservationForm from "./ObservationForm.tsx";
 import ExportDialog from "./ExportDialog";
 import ObservationItem from "./ObservationItem";
@@ -32,6 +34,8 @@ function MyObservations({ onBack }: MyObservationsProps) {
   const [showExportDialog, setShowExportDialog] = useState(false);
   const [locationSearch, setLocationSearch] = useState("");
   const [showLocationResults, setShowLocationResults] = useState(false);
+  const [dateFrom, setDateFrom] = useState<Dayjs | null>(null);
+  const [dateTo, setDateTo] = useState<Dayjs | null>(null);
   const [searchParams, setSearchParams] = useSearchParams();
   const view = searchParams.get("view") === "table" ? "table" : "list";
   const setView = (next: "list" | "table") => {
@@ -129,14 +133,30 @@ function MyObservations({ onBack }: MyObservationsProps) {
       )
     : locationSuggestions;
 
-  // Filter observations by a locality name search (matches saved and unsaved names)
-  const filteredObservations = locationSearch.trim()
-    ? observations.filter((obs) =>
-        obs.locationName
-          ?.toLowerCase()
-          .includes(locationSearch.trim().toLowerCase()),
-      )
-    : observations;
+  // Filter observations by locality name search (matches saved and unsaved
+  // names) and/or a startDate range
+  const filteredObservations = observations.filter((obs) => {
+    if (
+      locationSearch.trim() &&
+      !obs.locationName
+        ?.toLowerCase()
+        .includes(locationSearch.trim().toLowerCase())
+    ) {
+      return false;
+    }
+
+    if (dateFrom || dateTo) {
+      const startDate = dayjs(obs.startDate);
+      if (dateFrom && startDate.isBefore(dateFrom.startOf("day"))) {
+        return false;
+      }
+      if (dateTo && startDate.isAfter(dateTo.endOf("day"))) {
+        return false;
+      }
+    }
+
+    return true;
+  });
 
   const unexportedCount = getUnexportedCount(filteredObservations);
 
@@ -145,84 +165,100 @@ function MyObservations({ onBack }: MyObservationsProps) {
   return (
     <div className="w-full min-h-screen bg-sand dark:bg-bark pb-16 md:pb-0">
       <Header title={"kikket på"} />
-      <div
-        className={twMerge(
-          "mx-auto p-lg md:p-xl",
-          view === "table" ? "max-w-full" : "max-w-4xl",
-        )}
-      >
-        <div className="mb-lg flex flex-col md:flex-row justify-between items-start md:items-center gap-md">
+      <div className="mx-auto max-w-full p-lg md:p-xl">
+        <div className="mb-lg flex flex-col md:flex-row justify-between items-start md:items-center gap-md flex-wrap">
           <div className="hidden md:block">
             <Button onClick={onBack} variant="outline">
               ← Tilbake til kart
             </Button>
           </div>
 
-          {/* Location search */}
-          {locationSuggestions.length > 0 && (
-            <div className="relative w-full md:w-64">
-              <Search
-                size={16}
-                className="absolute left-3 top-1/2 -translate-y-1/2 text-slate pointer-events-none"
-              />
-              <Input
-                type="text"
-                placeholder="Søk etter lokalitet..."
-                value={locationSearch}
-                className={twMerge("pl-8", locationSearch && "pr-8")}
-                onChange={(e) => {
-                  setLocationSearch(e.target.value);
-                  setShowLocationResults(true);
-                }}
-                onFocus={() => setShowLocationResults(true)}
-                onBlur={() =>
-                  setTimeout(() => setShowLocationResults(false), 150)
-                }
-              />
-              {locationSearch && (
-                <button
-                  type="button"
-                  onClick={() => {
-                    setLocationSearch("");
-                    setShowLocationResults(false);
+          <div className="flex flex-wrap items-center gap-2 flex-1">
+            {/* Location search */}
+            {locationSuggestions.length > 0 && (
+              <div className="relative w-full md:w-56">
+                <Search
+                  size={16}
+                  className="absolute left-3 top-1/2 -translate-y-1/2 text-slate pointer-events-none"
+                />
+                <Input
+                  type="text"
+                  placeholder="Søk etter lokalitet..."
+                  value={locationSearch}
+                  className={twMerge("pl-8", locationSearch && "pr-8")}
+                  onChange={(e) => {
+                    setLocationSearch(e.target.value);
+                    setShowLocationResults(true);
                   }}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-slate hover:text-bark dark:hover:text-sand"
-                  aria-label="Fjern lokalitetsfilter"
-                >
-                  <X size={14} />
-                </button>
-              )}
-              {showLocationResults &&
-                filteredLocationSuggestions.length > 0 && (
-                  <div className="absolute z-[1100] w-full mt-1 bg-white dark:bg-bark border-2 border-slate-border dark:border-slate rounded-md shadow-custom-lg overflow-hidden">
-                    <div className="max-h-60 overflow-y-auto p-1">
-                      {filteredLocationSuggestions.map((suggestion) => (
-                        <button
-                          key={suggestion.name}
-                          type="button"
-                          onMouseDown={(e) => e.preventDefault()}
-                          onClick={() => {
-                            setLocationSearch(suggestion.name);
-                            setShowLocationResults(false);
-                          }}
-                          className="w-full flex items-center gap-1.5 text-left px-2 py-2 rounded-md hover:bg-sand dark:hover:bg-forest transition-colors"
-                        >
-                          {suggestion.isSaved && (
-                            <MapPinned
-                              size={14}
-                              className="shrink-0 text-violet-600 dark:text-violet-400"
-                            />
-                          )}
-                          <span className="text-sm text-bark dark:text-sand truncate">
-                            {suggestion.name}
-                          </span>
-                        </button>
-                      ))}
-                    </div>
-                  </div>
+                  onFocus={() => setShowLocationResults(true)}
+                  onBlur={() =>
+                    setTimeout(() => setShowLocationResults(false), 150)
+                  }
+                />
+                {locationSearch && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setLocationSearch("");
+                      setShowLocationResults(false);
+                    }}
+                    className="absolute right-3 top-1/2 -translate-y-1/2 text-slate hover:text-bark dark:hover:text-sand"
+                    aria-label="Fjern lokalitetsfilter"
+                  >
+                    <X size={14} />
+                  </button>
                 )}
+                {showLocationResults &&
+                  filteredLocationSuggestions.length > 0 && (
+                    <div className="absolute z-[1100] w-full mt-1 bg-white dark:bg-bark border-2 border-slate-border dark:border-slate rounded-md shadow-custom-lg overflow-hidden">
+                      <div className="max-h-60 overflow-y-auto p-1">
+                        {filteredLocationSuggestions.map((suggestion) => (
+                          <button
+                            key={suggestion.name}
+                            type="button"
+                            onMouseDown={(e) => e.preventDefault()}
+                            onClick={() => {
+                              setLocationSearch(suggestion.name);
+                              setShowLocationResults(false);
+                            }}
+                            className="w-full flex items-center gap-1.5 text-left px-2 py-2 rounded-md hover:bg-sand dark:hover:bg-forest transition-colors"
+                          >
+                            {suggestion.isSaved && (
+                              <MapPinned
+                                size={14}
+                                className="shrink-0 text-violet-600 dark:text-violet-400"
+                              />
+                            )}
+                            <span className="text-sm text-bark dark:text-sand truncate">
+                              {suggestion.name}
+                            </span>
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+              </div>
+            )}
+
+            {/* Date range filter */}
+            <div className="flex items-center gap-1.5">
+              <DatePicker
+                value={dateFrom}
+                onChange={setDateFrom}
+                onClear={() => setDateFrom(null)}
+                placeholder="Fra dato"
+                className="w-36"
+              />
+              <span className="text-slate text-sm">–</span>
+              <DatePicker
+                value={dateTo}
+                onChange={setDateTo}
+                onClear={() => setDateTo(null)}
+                placeholder="Til dato"
+                className="w-36"
+              />
             </div>
-          )}
+          </div>
 
           <div className="flex items-center gap-2 ml-auto">
             <div className="flex items-center border-2 border-moss rounded-md overflow-hidden">

--- a/src/react-app/components/MyObservations.tsx
+++ b/src/react-app/components/MyObservations.tsx
@@ -192,34 +192,35 @@ function MyObservations({ onBack }: MyObservationsProps) {
                   <X size={14} />
                 </button>
               )}
-              {showLocationResults && filteredLocationSuggestions.length > 0 && (
-                <div className="absolute z-[1100] w-full mt-1 bg-white dark:bg-bark border-2 border-slate-border dark:border-slate rounded-md shadow-custom-lg overflow-hidden">
-                  <div className="max-h-60 overflow-y-auto p-1">
-                    {filteredLocationSuggestions.map((suggestion) => (
-                      <button
-                        key={suggestion.name}
-                        type="button"
-                        onMouseDown={(e) => e.preventDefault()}
-                        onClick={() => {
-                          setLocationSearch(suggestion.name);
-                          setShowLocationResults(false);
-                        }}
-                        className="w-full flex items-center gap-1.5 text-left px-2 py-2 rounded-md hover:bg-sand dark:hover:bg-forest transition-colors"
-                      >
-                        {suggestion.isSaved && (
-                          <MapPinned
-                            size={14}
-                            className="shrink-0 text-violet-600 dark:text-violet-400"
-                          />
-                        )}
-                        <span className="text-sm text-bark dark:text-sand truncate">
-                          {suggestion.name}
-                        </span>
-                      </button>
-                    ))}
+              {showLocationResults &&
+                filteredLocationSuggestions.length > 0 && (
+                  <div className="absolute z-[1100] w-full mt-1 bg-white dark:bg-bark border-2 border-slate-border dark:border-slate rounded-md shadow-custom-lg overflow-hidden">
+                    <div className="max-h-60 overflow-y-auto p-1">
+                      {filteredLocationSuggestions.map((suggestion) => (
+                        <button
+                          key={suggestion.name}
+                          type="button"
+                          onMouseDown={(e) => e.preventDefault()}
+                          onClick={() => {
+                            setLocationSearch(suggestion.name);
+                            setShowLocationResults(false);
+                          }}
+                          className="w-full flex items-center gap-1.5 text-left px-2 py-2 rounded-md hover:bg-sand dark:hover:bg-forest transition-colors"
+                        >
+                          {suggestion.isSaved && (
+                            <MapPinned
+                              size={14}
+                              className="shrink-0 text-violet-600 dark:text-violet-400"
+                            />
+                          )}
+                          <span className="text-sm text-bark dark:text-sand truncate">
+                            {suggestion.name}
+                          </span>
+                        </button>
+                      ))}
+                    </div>
                   </div>
-                </div>
-              )}
+                )}
             </div>
           )}
 
@@ -290,7 +291,10 @@ function MyObservations({ onBack }: MyObservationsProps) {
             </p>
           </div>
         ) : view === "table" ? (
-          <ObservationsTable observations={filteredObservations} />
+          <ObservationsTable
+            observations={filteredObservations}
+            onEdit={setEditingId}
+          />
         ) : (
           <div className="flex flex-col space-y-md">
             {filteredObservations.map((observation) => (

--- a/src/react-app/components/MyObservations.tsx
+++ b/src/react-app/components/MyObservations.tsx
@@ -1,9 +1,18 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useSearchParams } from "react-router-dom";
-import { FileSpreadsheet, Filter, LayoutList, MapPin, Table2 } from "lucide-react";
+import {
+  FileSpreadsheet,
+  LayoutList,
+  MapPin,
+  MapPinned,
+  Search,
+  Table2,
+  X,
+} from "lucide-react";
 import { useObservations } from "../context/ObservationsContext";
 import { useLocations } from "../context/LocationsContext";
 import { Button } from "./ui/button";
+import { Input } from "./ui/input.tsx";
 import ObservationForm from "./ObservationForm.tsx";
 import ExportDialog from "./ExportDialog";
 import ObservationItem from "./ObservationItem";
@@ -21,7 +30,8 @@ function MyObservations({ onBack }: MyObservationsProps) {
   const { locations } = useLocations();
   const [editingId, setEditingId] = useState<string | null>(null);
   const [showExportDialog, setShowExportDialog] = useState(false);
-  const [filterLocationId, setFilterLocationId] = useState<string | null>(null);
+  const [locationSearch, setLocationSearch] = useState("");
+  const [showLocationResults, setShowLocationResults] = useState(false);
   const [searchParams, setSearchParams] = useSearchParams();
   const view = searchParams.get("view") === "table" ? "table" : "list";
   const setView = (next: "list" | "table") => {
@@ -91,9 +101,41 @@ function MyObservations({ onBack }: MyObservationsProps) {
     }
   };
 
-  // Filter observations by location if a filter is active
-  const filteredObservations = filterLocationId
-    ? observations.filter((obs) => obs.locationId === filterLocationId)
+  // Distinct locality names actually used across observations, so unsaved
+  // (free-text) localities show up as suggestions too, not just saved ones.
+  const locationSuggestions = useMemo(() => {
+    const savedNamesByName = new Map(
+      locations.map((loc) => [loc.name.toLowerCase(), loc]),
+    );
+    const seen = new Set<string>();
+    const suggestions: { name: string; isSaved: boolean }[] = [];
+
+    for (const obs of observations) {
+      const name = obs.locationName?.trim();
+      if (!name || seen.has(name.toLowerCase())) continue;
+      seen.add(name.toLowerCase());
+      suggestions.push({
+        name,
+        isSaved: savedNamesByName.has(name.toLowerCase()),
+      });
+    }
+
+    return suggestions.sort((a, b) => a.name.localeCompare(b.name, "no"));
+  }, [observations, locations]);
+
+  const filteredLocationSuggestions = locationSearch.trim()
+    ? locationSuggestions.filter((s) =>
+        s.name.toLowerCase().includes(locationSearch.trim().toLowerCase()),
+      )
+    : locationSuggestions;
+
+  // Filter observations by a locality name search (matches saved and unsaved names)
+  const filteredObservations = locationSearch.trim()
+    ? observations.filter((obs) =>
+        obs.locationName
+          ?.toLowerCase()
+          .includes(locationSearch.trim().toLowerCase()),
+      )
     : observations;
 
   const unexportedCount = getUnexportedCount(filteredObservations);
@@ -116,22 +158,68 @@ function MyObservations({ onBack }: MyObservationsProps) {
             </Button>
           </div>
 
-          {/* Location filter */}
-          {locations.length > 0 && (
-            <div className="flex items-center gap-2 w-full md:w-auto">
-              <Filter size={20} className="text-bark dark:text-sand" />
-              <select
-                value={filterLocationId || ""}
-                onChange={(e) => setFilterLocationId(e.target.value || null)}
-                className="flex-1 md:flex-initial p-2 rounded border-2 border-moss bg-sand dark:bg-bark text-bark dark:text-sand"
-              >
-                <option value="">Alle observasjoner</option>
-                {locations.map((location) => (
-                  <option key={location.id} value={location.id}>
-                    {location.name}
-                  </option>
-                ))}
-              </select>
+          {/* Location search */}
+          {locationSuggestions.length > 0 && (
+            <div className="relative w-full md:w-64">
+              <Search
+                size={16}
+                className="absolute left-3 top-1/2 -translate-y-1/2 text-slate pointer-events-none"
+              />
+              <Input
+                type="text"
+                placeholder="Søk etter lokalitet..."
+                value={locationSearch}
+                className={twMerge("pl-8", locationSearch && "pr-8")}
+                onChange={(e) => {
+                  setLocationSearch(e.target.value);
+                  setShowLocationResults(true);
+                }}
+                onFocus={() => setShowLocationResults(true)}
+                onBlur={() =>
+                  setTimeout(() => setShowLocationResults(false), 150)
+                }
+              />
+              {locationSearch && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setLocationSearch("");
+                    setShowLocationResults(false);
+                  }}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-slate hover:text-bark dark:hover:text-sand"
+                  aria-label="Fjern lokalitetsfilter"
+                >
+                  <X size={14} />
+                </button>
+              )}
+              {showLocationResults && filteredLocationSuggestions.length > 0 && (
+                <div className="absolute z-[1100] w-full mt-1 bg-white dark:bg-bark border-2 border-slate-border dark:border-slate rounded-md shadow-custom-lg overflow-hidden">
+                  <div className="max-h-60 overflow-y-auto p-1">
+                    {filteredLocationSuggestions.map((suggestion) => (
+                      <button
+                        key={suggestion.name}
+                        type="button"
+                        onMouseDown={(e) => e.preventDefault()}
+                        onClick={() => {
+                          setLocationSearch(suggestion.name);
+                          setShowLocationResults(false);
+                        }}
+                        className="w-full flex items-center gap-1.5 text-left px-2 py-2 rounded-md hover:bg-sand dark:hover:bg-forest transition-colors"
+                      >
+                        {suggestion.isSaved && (
+                          <MapPinned
+                            size={14}
+                            className="shrink-0 text-violet-600 dark:text-violet-400"
+                          />
+                        )}
+                        <span className="text-sm text-bark dark:text-sand truncate">
+                          {suggestion.name}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
             </div>
           )}
 

--- a/src/react-app/components/MyObservations.tsx
+++ b/src/react-app/components/MyObservations.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { FileSpreadsheet, Filter, LayoutList, MapPin, Table2 } from "lucide-react";
 import { useObservations } from "../context/ObservationsContext";
 import { useLocations } from "../context/LocationsContext";
@@ -21,7 +22,22 @@ function MyObservations({ onBack }: MyObservationsProps) {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [showExportDialog, setShowExportDialog] = useState(false);
   const [filterLocationId, setFilterLocationId] = useState<string | null>(null);
-  const [view, setView] = useState<"list" | "table">("list");
+  const [searchParams, setSearchParams] = useSearchParams();
+  const view = searchParams.get("view") === "table" ? "table" : "list";
+  const setView = (next: "list" | "table") => {
+    setSearchParams(
+      (prev) => {
+        const params = new URLSearchParams(prev);
+        if (next === "list") {
+          params.delete("view");
+        } else {
+          params.set("view", next);
+        }
+        return params;
+      },
+      { replace: true },
+    );
+  };
 
   const formatDate = (dateString: string) => {
     const date = new Date(dateString);

--- a/src/react-app/components/ObservationsTable.tsx
+++ b/src/react-app/components/ObservationsTable.tsx
@@ -50,9 +50,7 @@ const formatTime = (value?: string) =>
 const columnHelper = createColumnHelper<FlatRow>();
 
 /** Text/number input that auto-focuses and selects its content the moment it's mounted, so the first click into edit mode is ready to type over. */
-const AutoFocusInput = (
-  props: React.InputHTMLAttributes<HTMLInputElement>,
-) => {
+const AutoFocusInput = (props: React.InputHTMLAttributes<HTMLInputElement>) => {
   const ref = useRef<HTMLInputElement>(null);
   useEffect(() => {
     ref.current?.focus();
@@ -129,7 +127,9 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
 
   const sortedObservations = useMemo(
     () =>
-      [...observations].sort((a, b) => dayjs(b.startDate).diff(dayjs(a.startDate))),
+      [...observations].sort((a, b) =>
+        dayjs(b.startDate).diff(dayjs(a.startDate)),
+      ),
     [observations],
   );
 
@@ -295,7 +295,11 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
             <AutoFocusInput
               defaultValue={observation.locationName || ""}
               onBlur={(e) => {
-                setObservationField(observation, "locationName", e.target.value);
+                setObservationField(
+                  observation,
+                  "locationName",
+                  e.target.value,
+                );
                 setEditingCell(null);
               }}
               onKeyDown={(e) => {
@@ -371,16 +375,24 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
           const { observation, species, speciesIndex, rowId } = row.original;
           const taxonGroup = species.species.TaxonGroup || "";
           const cellKey = `${rowId}-unit`;
-          return pickerCell(cellKey, species.unit, ({ defaultOpen, onOpenChange }) => (
-            <Combobox
-              variant="ghost"
-              defaultOpen={defaultOpen}
-              onOpenChange={onOpenChange}
-              value={species.unit || ""}
-              onChange={(v) => setSpeciesField(observation, speciesIndex, "unit", v)}
-              options={getUnitOptionsForTaxonGroup(taxonGroup) as ComboboxOption[]}
-            />
-          ));
+          return pickerCell(
+            cellKey,
+            species.unit,
+            ({ defaultOpen, onOpenChange }) => (
+              <Combobox
+                variant="ghost"
+                defaultOpen={defaultOpen}
+                onOpenChange={onOpenChange}
+                value={species.unit || ""}
+                onChange={(v) =>
+                  setSpeciesField(observation, speciesIndex, "unit", v)
+                }
+                options={
+                  getUnitOptionsForTaxonGroup(taxonGroup) as ComboboxOption[]
+                }
+              />
+            ),
+          );
         },
       }),
       columnHelper.display({
@@ -391,18 +403,24 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
           const { observation, species, speciesIndex, rowId } = row.original;
           const taxonGroup = species.species.TaxonGroup || "";
           const cellKey = `${rowId}-gender`;
-          return pickerCell(cellKey, species.gender, ({ defaultOpen, onOpenChange }) => (
-            <Combobox
-              variant="ghost"
-              defaultOpen={defaultOpen}
-              onOpenChange={onOpenChange}
-              value={species.gender || ""}
-              onChange={(v) => setSpeciesField(observation, speciesIndex, "gender", v)}
-              options={
-                getGenderOptionsForTaxonGroup(taxonGroup) as ComboboxOption[]
-              }
-            />
-          ));
+          return pickerCell(
+            cellKey,
+            species.gender,
+            ({ defaultOpen, onOpenChange }) => (
+              <Combobox
+                variant="ghost"
+                defaultOpen={defaultOpen}
+                onOpenChange={onOpenChange}
+                value={species.gender || ""}
+                onChange={(v) =>
+                  setSpeciesField(observation, speciesIndex, "gender", v)
+                }
+                options={
+                  getGenderOptionsForTaxonGroup(taxonGroup) as ComboboxOption[]
+                }
+              />
+            ),
+          );
         },
       }),
       columnHelper.display({
@@ -413,16 +431,24 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
           const { observation, species, speciesIndex, rowId } = row.original;
           const taxonGroup = species.species.TaxonGroup || "";
           const cellKey = `${rowId}-age`;
-          return pickerCell(cellKey, species.age, ({ defaultOpen, onOpenChange }) => (
-            <Combobox
-              variant="ghost"
-              defaultOpen={defaultOpen}
-              onOpenChange={onOpenChange}
-              value={species.age || ""}
-              onChange={(v) => setSpeciesField(observation, speciesIndex, "age", v)}
-              options={getAgeOptionsForTaxonGroup(taxonGroup) as ComboboxOption[]}
-            />
-          ));
+          return pickerCell(
+            cellKey,
+            species.age,
+            ({ defaultOpen, onOpenChange }) => (
+              <Combobox
+                variant="ghost"
+                defaultOpen={defaultOpen}
+                onOpenChange={onOpenChange}
+                value={species.age || ""}
+                onChange={(v) =>
+                  setSpeciesField(observation, speciesIndex, "age", v)
+                }
+                options={
+                  getAgeOptionsForTaxonGroup(taxonGroup) as ComboboxOption[]
+                }
+              />
+            ),
+          );
         },
       }),
       columnHelper.display({
@@ -433,18 +459,24 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
           const { observation, species, speciesIndex, rowId } = row.original;
           const taxonGroup = species.species.TaxonGroup || "";
           const cellKey = `${rowId}-method`;
-          return pickerCell(cellKey, species.method, ({ defaultOpen, onOpenChange }) => (
-            <Combobox
-              variant="ghost"
-              defaultOpen={defaultOpen}
-              onOpenChange={onOpenChange}
-              value={species.method || ""}
-              onChange={(v) => setSpeciesField(observation, speciesIndex, "method", v)}
-              options={
-                getMethodOptionsForTaxonGroup(taxonGroup) as ComboboxOption[]
-              }
-            />
-          ));
+          return pickerCell(
+            cellKey,
+            species.method,
+            ({ defaultOpen, onOpenChange }) => (
+              <Combobox
+                variant="ghost"
+                defaultOpen={defaultOpen}
+                onOpenChange={onOpenChange}
+                value={species.method || ""}
+                onChange={(v) =>
+                  setSpeciesField(observation, speciesIndex, "method", v)
+                }
+                options={
+                  getMethodOptionsForTaxonGroup(taxonGroup) as ComboboxOption[]
+                }
+              />
+            ),
+          );
         },
       }),
       columnHelper.display({
@@ -455,18 +487,26 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
           const { observation, species, speciesIndex, rowId } = row.original;
           const taxonGroup = species.species.TaxonGroup || "";
           const cellKey = `${rowId}-activity`;
-          return pickerCell(cellKey, species.activity, ({ defaultOpen, onOpenChange }) => (
-            <Combobox
-              variant="ghost"
-              defaultOpen={defaultOpen}
-              onOpenChange={onOpenChange}
-              value={species.activity || ""}
-              onChange={(v) => setSpeciesField(observation, speciesIndex, "activity", v)}
-              options={
-                getActivityOptionsForTaxonGroup(taxonGroup) as ComboboxOption[]
-              }
-            />
-          ));
+          return pickerCell(
+            cellKey,
+            species.activity,
+            ({ defaultOpen, onOpenChange }) => (
+              <Combobox
+                variant="ghost"
+                defaultOpen={defaultOpen}
+                onOpenChange={onOpenChange}
+                value={species.activity || ""}
+                onChange={(v) =>
+                  setSpeciesField(observation, speciesIndex, "activity", v)
+                }
+                options={
+                  getActivityOptionsForTaxonGroup(
+                    taxonGroup,
+                  ) as ComboboxOption[]
+                }
+              />
+            ),
+          );
         },
       }),
       columnHelper.display({
@@ -491,7 +531,11 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
                   setObservationField(
                     observation,
                     "startDate",
-                    base.year(v.year()).month(v.month()).date(v.date()).toISOString(),
+                    base
+                      .year(v.year())
+                      .month(v.month())
+                      .date(v.date())
+                      .toISOString(),
                   );
                 }}
               />
@@ -556,7 +600,11 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
                   setObservationField(
                     observation,
                     "endDate",
-                    base.year(v.year()).month(v.month()).date(v.date()).toISOString(),
+                    base
+                      .year(v.year())
+                      .month(v.month())
+                      .date(v.date())
+                      .toISOString(),
                   );
                 }}
               />
@@ -605,7 +653,12 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
               rows={2}
               defaultValue={species.comment || ""}
               onBlur={(e) => {
-                setSpeciesField(observation, speciesIndex, "comment", e.target.value);
+                setSpeciesField(
+                  observation,
+                  speciesIndex,
+                  "comment",
+                  e.target.value,
+                );
                 setEditingCell(null);
               }}
               onKeyDown={(e) => {
@@ -655,7 +708,11 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
             <AutoFocusInput
               defaultValue={observation.observerName || ""}
               onBlur={(e) => {
-                setObservationField(observation, "observerName", e.target.value);
+                setObservationField(
+                  observation,
+                  "observerName",
+                  e.target.value,
+                );
                 setEditingCell(null);
               }}
               onKeyDown={(e) => {
@@ -782,10 +839,7 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
         <table className="border-collapse table-fixed">
           <colgroup>
             {table.getFlatHeaders().map((header) => (
-              <col
-                key={header.id}
-                style={{ width: header.getSize() }}
-              />
+              <col key={header.id} style={{ width: header.getSize() }} />
             ))}
           </colgroup>
           <thead>
@@ -815,7 +869,10 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
                 >
                   {row.getVisibleCells().map((cell) => (
                     <td key={cell.id} className={cellClass}>
-                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext(),
+                      )}
                     </td>
                   ))}
                 </tr>

--- a/src/react-app/components/ObservationsTable.tsx
+++ b/src/react-app/components/ObservationsTable.tsx
@@ -6,7 +6,7 @@ import {
   useReactTable,
 } from "@tanstack/react-table";
 import dayjs from "dayjs";
-import { Trash2 } from "lucide-react";
+import { ChevronLeft, ChevronRight, Trash2 } from "lucide-react";
 import { Observation, Species } from "../types/observation.ts";
 import { useObservations } from "../context/ObservationsContext.tsx";
 import { Input } from "./ui/input.tsx";
@@ -14,12 +14,15 @@ import { Textarea } from "./ui/textarea.tsx";
 import { Combobox, ComboboxOption } from "./ui/combobox.tsx";
 import { DatePicker } from "./ui/date-picker.tsx";
 import { TimePicker } from "./ui/time-picker.tsx";
+import { Button } from "./ui/button.tsx";
 import { getAgeOptionsForTaxonGroup } from "../lib/ageOptions.ts";
 import { getGenderOptionsForTaxonGroup } from "../lib/genderOptions.ts";
 import { getUnitOptionsForTaxonGroup } from "../lib/unitOptions.ts";
 import { getMethodOptionsForTaxonGroup } from "../lib/methodOptions.ts";
 import { getActivityOptionsForTaxonGroup } from "../lib/activityOptions.ts";
 import { twMerge } from "tailwind-merge";
+
+const OBSERVATIONS_PER_PAGE = 20;
 
 interface ObservationsTableProps {
   observations: Observation[];
@@ -117,13 +120,42 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
     });
   };
 
+  const [page, setPage] = useState(0);
+
+  const goToPage = (next: number) => {
+    setPage(next);
+    setEditingCell(null);
+  };
+
+  const sortedObservations = useMemo(
+    () =>
+      [...observations].sort((a, b) => dayjs(b.startDate).diff(dayjs(a.startDate))),
+    [observations],
+  );
+
+  const pageCount = Math.max(
+    1,
+    Math.ceil(sortedObservations.length / OBSERVATIONS_PER_PAGE),
+  );
+  const clampedPage = Math.min(page, pageCount - 1);
+
+  useEffect(() => {
+    if (page !== clampedPage) setPage(clampedPage);
+  }, [page, clampedPage]);
+
+  const pageObservations = useMemo(
+    () =>
+      sortedObservations.slice(
+        clampedPage * OBSERVATIONS_PER_PAGE,
+        (clampedPage + 1) * OBSERVATIONS_PER_PAGE,
+      ),
+    [sortedObservations, clampedPage],
+  );
+
   const data = useMemo<FlatRow[]>(() => {
-    const sorted = [...observations].sort((a, b) =>
-      dayjs(b.startDate).diff(dayjs(a.startDate)),
-    );
     let groupCount = 0;
     let lastObservationId: string | null = null;
-    return sorted.flatMap((observation) =>
+    return pageObservations.flatMap((observation) =>
       observation.species.map((species, speciesIndex) => {
         const isNewGroup = observation.id !== lastObservationId;
         if (isNewGroup) groupCount++;
@@ -138,7 +170,7 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
         };
       }),
     );
-  }, [observations]);
+  }, [pageObservations]);
 
   /** Text-style cell: shows plain text, and the very first click both enters edit mode and focuses the input (no second click needed). */
   const textCell = (
@@ -722,40 +754,83 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
   });
 
   return (
-    <div className="overflow-x-auto border-2 border-moss/40 rounded-md">
-      <table className="border-collapse w-full">
-        <thead>
-          {table.getHeaderGroups().map((headerGroup) => (
-            <tr key={headerGroup.id}>
-              {headerGroup.headers.map((header) => (
-                <th key={header.id} className={headerClass}>
-                  {flexRender(header.column.columnDef.header, header.getContext())}
-                </th>
-              ))}
-            </tr>
-          ))}
-        </thead>
-        <tbody>
-          {table.getRowModel().rows.map((row) => {
-            const { isNewGroup, groupParity } = row.original;
-            return (
-              <tr
-                key={row.id}
-                className={twMerge(
-                  groupParity ? "bg-moss/5 dark:bg-moss/10" : "",
-                  isNewGroup ? "border-t-2 border-moss/40" : "",
-                )}
-              >
-                {row.getVisibleCells().map((cell) => (
-                  <td key={cell.id} className={cellClass}>
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </td>
+    <div className="border-2 border-moss/40 rounded-md overflow-hidden">
+      <div className="overflow-x-auto">
+        <table className="border-collapse w-full">
+          <thead>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <tr key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <th key={header.id} className={headerClass}>
+                    {flexRender(
+                      header.column.columnDef.header,
+                      header.getContext(),
+                    )}
+                  </th>
                 ))}
               </tr>
-            );
-          })}
-        </tbody>
-      </table>
+            ))}
+          </thead>
+          <tbody>
+            {table.getRowModel().rows.map((row) => {
+              const { isNewGroup, groupParity } = row.original;
+              return (
+                <tr
+                  key={row.id}
+                  className={twMerge(
+                    groupParity ? "bg-moss/5 dark:bg-moss/10" : "",
+                    isNewGroup ? "border-t-2 border-moss/40" : "",
+                  )}
+                >
+                  {row.getVisibleCells().map((cell) => (
+                    <td key={cell.id} className={cellClass}>
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </td>
+                  ))}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {pageCount > 1 && (
+        <div className="flex items-center justify-between gap-md px-md py-sm border-t-2 border-moss/40 bg-sand dark:bg-forest">
+          <span className="text-xs text-slate">
+            Observasjon {clampedPage * OBSERVATIONS_PER_PAGE + 1}–
+            {Math.min(
+              (clampedPage + 1) * OBSERVATIONS_PER_PAGE,
+              sortedObservations.length,
+            )}{" "}
+            av {sortedObservations.length}
+          </span>
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={clampedPage === 0}
+              onClick={() => goToPage(Math.max(0, clampedPage - 1))}
+              aria-label="Forrige side"
+            >
+              <ChevronLeft size={16} />
+            </Button>
+            <span className="text-xs text-bark dark:text-sand whitespace-nowrap">
+              Side {clampedPage + 1} av {pageCount}
+            </span>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={clampedPage >= pageCount - 1}
+              onClick={() => goToPage(Math.min(pageCount - 1, clampedPage + 1))}
+              aria-label="Neste side"
+            >
+              <ChevronRight size={16} />
+            </Button>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/react-app/components/ObservationsTable.tsx
+++ b/src/react-app/components/ObservationsTable.tsx
@@ -29,11 +29,11 @@ import { getMethodOptionsForTaxonGroup } from "../lib/methodOptions.ts";
 import { getActivityOptionsForTaxonGroup } from "../lib/activityOptions.ts";
 import { twMerge } from "tailwind-merge";
 
-const ROWS_PER_PAGE = 20;
+const ROWS_PER_PAGE = 40;
 
 // Pin the first three columns (actions, species name, locality name) so
 // they stay visible while scrolling horizontally through the rest of the table.
-const STICKY_COLUMN_IDS = ["actions", "speciesName", "locationName"];
+const STICKY_COLUMN_IDS = ["actions", "speciesName"];
 
 interface ObservationsTableProps {
   observations: Observation[];
@@ -908,31 +908,29 @@ const ObservationsTable = ({
     columns,
     getCoreRowModel: getCoreRowModel(),
     getRowId: (row) => row.rowId,
+    state: {
+      columnPinning: { left: STICKY_COLUMN_IDS },
+    },
   });
 
-  const stickyLeftOffsets = useMemo(() => {
-    const offsets: Record<string, number> = {};
-    let left = 0;
-    for (const header of table.getFlatHeaders()) {
-      if (!STICKY_COLUMN_IDS.includes(header.column.id)) continue;
-      offsets[header.column.id] = left;
-      left += header.getSize();
-    }
-    return offsets;
-  }, [table]);
+  const getStickyStyle = (
+    column: ReturnType<typeof table.getColumn>,
+    zIndex: number,
+  ): React.CSSProperties | undefined => {
+    if (!column || column.getIsPinned() !== "left") return undefined;
+    return {
+      position: "sticky",
+      left: column.getAfter("right"),
+      zIndex,
+    };
+  };
 
-  const getStickyStyle = (columnId: string): React.CSSProperties | undefined =>
-    columnId in stickyLeftOffsets
-      ? { position: "sticky", left: stickyLeftOffsets[columnId], zIndex: 5 }
-      : undefined;
-
-  const lastStickyColumnId =
-    STICKY_COLUMN_IDS[STICKY_COLUMN_IDS.length - 1];
+  const lastStickyColumnId = STICKY_COLUMN_IDS[STICKY_COLUMN_IDS.length - 1];
 
   return (
     <div className="border-2 border-moss/40 rounded-sm overflow-hidden">
       <div className="overflow-x-auto">
-        <table className="border-collapse table-fixed">
+        <table className="border-separate border-spacing-0 table-fixed">
           <colgroup>
             {table.getFlatHeaders().map((header) => (
               <col key={header.id} style={{ width: header.getSize() }} />
@@ -946,12 +944,11 @@ const ObservationsTable = ({
                     key={header.id}
                     className={twMerge(
                       headerClass,
-                      header.column.id in stickyLeftOffsets &&
-                        "z-20 bg-sand dark:bg-forest",
-                      header.column.id === lastStickyColumnId &&
-                        "border-r-2 border-moss/40",
+                      header.column.getIsPinned() === "left" &&
+                        "bg-sand dark:bg-forest",
+                      header.column.id === lastStickyColumnId && "border-r-2",
                     )}
-                    style={getStickyStyle(header.column.id)}
+                    style={getStickyStyle(header.column, 20)}
                   >
                     {flexRender(
                       header.column.columnDef.header,
@@ -979,7 +976,7 @@ const ObservationsTable = ({
                           "border-r-2 border-moss/40",
                         isNewGroup && "border-t-2 border-moss/40",
                       )}
-                      style={getStickyStyle(cell.column.id)}
+                      style={getStickyStyle(cell.column, 5)}
                     >
                       {flexRender(
                         cell.column.columnDef.cell,

--- a/src/react-app/components/ObservationsTable.tsx
+++ b/src/react-app/components/ObservationsTable.tsx
@@ -237,6 +237,7 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
       columnHelper.display({
         id: "remove",
         header: "",
+        size: 44,
         cell: ({ row }) => {
           const { observation, speciesIndex } = row.original;
           return (
@@ -254,6 +255,7 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
       columnHelper.display({
         id: "speciesName",
         header: "Artsnavn",
+        size: 200,
         cell: ({ row }) => {
           const { observation, species, speciesIndex, rowId } = row.original;
           return textCell(
@@ -284,6 +286,7 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
       columnHelper.display({
         id: "locationName",
         header: "Lokalitetsnavn",
+        size: 180,
         cell: ({ row }) => {
           const { observation, rowId } = row.original;
           return textCell(
@@ -306,6 +309,7 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
       columnHelper.display({
         id: "uncertaintyRadius",
         header: "Nøyaktighet",
+        size: 130,
         cell: ({ row }) => {
           const { observation, rowId } = row.original;
           return textCell(
@@ -334,6 +338,7 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
       columnHelper.display({
         id: "count",
         header: "Antall",
+        size: 100,
         cell: ({ row }) => {
           const { observation, species, speciesIndex, rowId } = row.original;
           return textCell(
@@ -361,6 +366,7 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
       columnHelper.display({
         id: "unit",
         header: "Enhet",
+        size: 150,
         cell: ({ row }) => {
           const { observation, species, speciesIndex, rowId } = row.original;
           const taxonGroup = species.species.TaxonGroup || "";
@@ -380,6 +386,7 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
       columnHelper.display({
         id: "gender",
         header: "Kjønn",
+        size: 150,
         cell: ({ row }) => {
           const { observation, species, speciesIndex, rowId } = row.original;
           const taxonGroup = species.species.TaxonGroup || "";
@@ -401,6 +408,7 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
       columnHelper.display({
         id: "age",
         header: "Alder",
+        size: 150,
         cell: ({ row }) => {
           const { observation, species, speciesIndex, rowId } = row.original;
           const taxonGroup = species.species.TaxonGroup || "";
@@ -420,6 +428,7 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
       columnHelper.display({
         id: "method",
         header: "Metode",
+        size: 180,
         cell: ({ row }) => {
           const { observation, species, speciesIndex, rowId } = row.original;
           const taxonGroup = species.species.TaxonGroup || "";
@@ -441,6 +450,7 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
       columnHelper.display({
         id: "activity",
         header: "Aktivitet",
+        size: 180,
         cell: ({ row }) => {
           const { observation, species, speciesIndex, rowId } = row.original;
           const taxonGroup = species.species.TaxonGroup || "";
@@ -462,6 +472,7 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
       columnHelper.display({
         id: "startDateDate",
         header: "Fra dato",
+        size: 140,
         cell: ({ row }) => {
           const { observation, rowId } = row.original;
           const cellKey = `${rowId}-startDateDate`;
@@ -491,6 +502,7 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
       columnHelper.display({
         id: "startDateTime",
         header: "Fra klokkeslett",
+        size: 130,
         cell: ({ row }) => {
           const { observation, rowId } = row.original;
           return textCell(
@@ -519,6 +531,7 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
       columnHelper.display({
         id: "endDateDate",
         header: "Til dato",
+        size: 140,
         cell: ({ row }) => {
           const { observation, rowId } = row.original;
           const cellKey = `${rowId}-endDateDate`;
@@ -554,6 +567,7 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
       columnHelper.display({
         id: "endDateTime",
         header: "Til klokkeslett",
+        size: 130,
         cell: ({ row }) => {
           const { observation, rowId } = row.original;
           return textCell(
@@ -581,6 +595,7 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
       columnHelper.display({
         id: "speciesComment",
         header: "Kommentar",
+        size: 220,
         cell: ({ row }) => {
           const { observation, species, speciesIndex, rowId } = row.original;
           return textCell(
@@ -603,6 +618,7 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
       columnHelper.display({
         id: "privateComment",
         header: "Privat kommentar",
+        size: 220,
         cell: ({ row }) => {
           const { observation, species, speciesIndex, rowId } = row.original;
           return textCell(
@@ -630,6 +646,7 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
       columnHelper.display({
         id: "observerName",
         header: "Medobservatør",
+        size: 170,
         cell: ({ row }) => {
           const { observation, rowId } = row.original;
           return textCell(
@@ -652,6 +669,7 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
       columnHelper.display({
         id: "project",
         header: "Prosjekt",
+        size: 150,
         cell: ({ row }) => {
           const { observation, rowId } = row.original;
           return textCell(
@@ -674,6 +692,7 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
       columnHelper.display({
         id: "notRediscovered",
         header: "Ikke gjenfunnet",
+        size: 130,
         cell: ({ row }) => {
           const { observation, species, speciesIndex } = row.original;
           return toggleCell(species.notRediscovered, () =>
@@ -689,6 +708,7 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
       columnHelper.display({
         id: "notFound",
         header: "Ikke funnet",
+        size: 120,
         cell: ({ row }) => {
           const { observation, species, speciesIndex } = row.original;
           return toggleCell(species.notFound, () =>
@@ -704,6 +724,7 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
       columnHelper.display({
         id: "secondHand",
         header: "Andrehånds",
+        size: 120,
         cell: ({ row }) => {
           const { observation, species, speciesIndex } = row.original;
           return toggleCell(species.secondHand, () =>
@@ -719,6 +740,7 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
       columnHelper.display({
         id: "uncertainIdentification",
         header: "Usikker artsbestemming",
+        size: 160,
         cell: ({ row }) => {
           const { observation, species, speciesIndex } = row.original;
           return toggleCell(species.uncertainIdentification, () =>
@@ -734,6 +756,7 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
       columnHelper.display({
         id: "hide",
         header: "Skjul",
+        size: 100,
         cell: ({ row }) => {
           const { observation, species, speciesIndex } = row.original;
           return toggleCell(species.hide, () =>
@@ -756,7 +779,15 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
   return (
     <div className="border-2 border-moss/40 rounded-md overflow-hidden">
       <div className="overflow-x-auto">
-        <table className="border-collapse w-full">
+        <table className="border-collapse table-fixed">
+          <colgroup>
+            {table.getFlatHeaders().map((header) => (
+              <col
+                key={header.id}
+                style={{ width: header.getSize() }}
+              />
+            ))}
+          </colgroup>
           <thead>
             {table.getHeaderGroups().map((headerGroup) => (
               <tr key={headerGroup.id}>

--- a/src/react-app/components/ObservationsTable.tsx
+++ b/src/react-app/components/ObservationsTable.tsx
@@ -31,6 +31,10 @@ import { twMerge } from "tailwind-merge";
 
 const ROWS_PER_PAGE = 20;
 
+// Pin the first three columns (actions, species name, locality name) so
+// they stay visible while scrolling horizontally through the rest of the table.
+const STICKY_COLUMN_IDS = ["actions", "speciesName", "locationName"];
+
 interface ObservationsTableProps {
   observations: Observation[];
   onEdit: (id: string) => void;
@@ -906,6 +910,25 @@ const ObservationsTable = ({
     getRowId: (row) => row.rowId,
   });
 
+  const stickyLeftOffsets = useMemo(() => {
+    const offsets: Record<string, number> = {};
+    let left = 0;
+    for (const header of table.getFlatHeaders()) {
+      if (!STICKY_COLUMN_IDS.includes(header.column.id)) continue;
+      offsets[header.column.id] = left;
+      left += header.getSize();
+    }
+    return offsets;
+  }, [table]);
+
+  const getStickyStyle = (columnId: string): React.CSSProperties | undefined =>
+    columnId in stickyLeftOffsets
+      ? { position: "sticky", left: stickyLeftOffsets[columnId], zIndex: 5 }
+      : undefined;
+
+  const lastStickyColumnId =
+    STICKY_COLUMN_IDS[STICKY_COLUMN_IDS.length - 1];
+
   return (
     <div className="border-2 border-moss/40 rounded-sm overflow-hidden">
       <div className="overflow-x-auto">
@@ -919,7 +942,17 @@ const ObservationsTable = ({
             {table.getHeaderGroups().map((headerGroup) => (
               <tr key={headerGroup.id}>
                 {headerGroup.headers.map((header) => (
-                  <th key={header.id} className={headerClass}>
+                  <th
+                    key={header.id}
+                    className={twMerge(
+                      headerClass,
+                      header.column.id in stickyLeftOffsets &&
+                        "z-20 bg-sand dark:bg-forest",
+                      header.column.id === lastStickyColumnId &&
+                        "border-r-2 border-moss/40",
+                    )}
+                    style={getStickyStyle(header.column.id)}
+                  >
                     {flexRender(
                       header.column.columnDef.header,
                       header.getContext(),
@@ -933,15 +966,21 @@ const ObservationsTable = ({
             {table.getRowModel().rows.map((row) => {
               const { isNewGroup, groupParity } = row.original;
               return (
-                <tr
-                  key={row.id}
-                  className={twMerge(
-                    groupParity ? "bg-moss/5 dark:bg-moss/10" : "",
-                    isNewGroup ? "border-t-2 border-moss/40" : "",
-                  )}
-                >
+                <tr key={row.id}>
                   {row.getVisibleCells().map((cell) => (
-                    <td key={cell.id} className={cellClass}>
+                    <td
+                      key={cell.id}
+                      className={twMerge(
+                        cellClass,
+                        groupParity
+                          ? "bg-sand dark:bg-forest-dark"
+                          : "bg-white dark:bg-bark",
+                        cell.column.id === lastStickyColumnId &&
+                          "border-r-2 border-moss/40",
+                        isNewGroup && "border-t-2 border-moss/40",
+                      )}
+                      style={getStickyStyle(cell.column.id)}
+                    >
                       {flexRender(
                         cell.column.columnDef.cell,
                         cell.getContext(),

--- a/src/react-app/components/ObservationsTable.tsx
+++ b/src/react-app/components/ObservationsTable.tsx
@@ -1,0 +1,681 @@
+import { ReactNode, useMemo, useState } from "react";
+import {
+  createColumnHelper,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import dayjs from "dayjs";
+import { Trash2 } from "lucide-react";
+import { Observation, Species } from "../types/observation.ts";
+import { useObservations } from "../context/ObservationsContext.tsx";
+import { Input } from "./ui/input.tsx";
+import { Textarea } from "./ui/textarea.tsx";
+import { Combobox, ComboboxOption } from "./ui/combobox.tsx";
+import { DatePicker } from "./ui/date-picker.tsx";
+import { TimePicker } from "./ui/time-picker.tsx";
+import { getAgeOptionsForTaxonGroup } from "../lib/ageOptions.ts";
+import { getGenderOptionsForTaxonGroup } from "../lib/genderOptions.ts";
+import { getUnitOptionsForTaxonGroup } from "../lib/unitOptions.ts";
+import { getMethodOptionsForTaxonGroup } from "../lib/methodOptions.ts";
+import { getActivityOptionsForTaxonGroup } from "../lib/activityOptions.ts";
+import { twMerge } from "tailwind-merge";
+
+interface ObservationsTableProps {
+  observations: Observation[];
+}
+
+interface FlatRow {
+  rowId: string;
+  observation: Observation;
+  species: Species;
+  speciesIndex: number;
+  isNewGroup: boolean;
+  groupParity: number;
+}
+
+const cellClass =
+  "px-2 py-1.5 text-sm text-bark dark:text-sand whitespace-nowrap align-middle";
+const headerClass =
+  "px-2 py-2 text-left text-xs font-semibold text-bark dark:text-sand whitespace-nowrap sticky top-0 bg-sand dark:bg-forest z-10 border-b-2 border-moss";
+
+const formatDate = (value?: string) =>
+  value && dayjs(value).isValid() ? dayjs(value).format("DD.MM.YYYY") : "";
+const formatTime = (value?: string) =>
+  value && dayjs(value).isValid() ? dayjs(value).format("HH:mm") : "";
+
+const columnHelper = createColumnHelper<FlatRow>();
+
+const ObservationsTable = ({ observations }: ObservationsTableProps) => {
+  const { updateObservation, deleteObservation } = useObservations();
+  const [editingCell, setEditingCell] = useState<string | null>(null);
+
+  const setObservationField = <K extends keyof Observation>(
+    observation: Observation,
+    field: K,
+    value: Observation[K],
+  ) => {
+    updateObservation({ ...observation, [field]: value });
+  };
+
+  const setSpeciesField = <K extends keyof Species>(
+    observation: Observation,
+    speciesIndex: number,
+    field: K,
+    value: Species[K],
+  ) => {
+    const nextSpecies = observation.species.map((s, i) =>
+      i === speciesIndex ? { ...s, [field]: value } : s,
+    );
+    updateObservation({ ...observation, species: nextSpecies });
+  };
+
+  const removeSpeciesRow = (observation: Observation, speciesIndex: number) => {
+    const removed = observation.species[speciesIndex];
+    const label =
+      removed.species.PrefferedPopularname ??
+      removed.species.ValidScientificName ??
+      "denne arten";
+
+    if (observation.species.length === 1) {
+      const confirmed = window.confirm(
+        `${label} er den siste arten på observasjonen. Fjerner du den, slettes hele observasjonen. Vil du fortsette?`,
+      );
+      if (!confirmed) return;
+      deleteObservation(observation.id);
+      return;
+    }
+
+    const confirmed = window.confirm(`Fjern ${label} fra observasjonen?`);
+    if (!confirmed) return;
+    updateObservation({
+      ...observation,
+      species: observation.species.filter((_, i) => i !== speciesIndex),
+    });
+  };
+
+  const data = useMemo<FlatRow[]>(() => {
+    const sorted = [...observations].sort((a, b) =>
+      dayjs(b.startDate).diff(dayjs(a.startDate)),
+    );
+    let groupCount = 0;
+    let lastObservationId: string | null = null;
+    return sorted.flatMap((observation) =>
+      observation.species.map((species, speciesIndex) => {
+        const isNewGroup = observation.id !== lastObservationId;
+        if (isNewGroup) groupCount++;
+        lastObservationId = observation.id;
+        return {
+          rowId: `${observation.id}-${speciesIndex}`,
+          observation,
+          species,
+          speciesIndex,
+          isNewGroup,
+          groupParity: groupCount % 2,
+        };
+      }),
+    );
+  }, [observations]);
+
+  const editableCell = (
+    cellKey: string,
+    display: ReactNode,
+    editControl: ReactNode,
+  ) => {
+    const isEditing = editingCell === cellKey;
+    return (
+      <div
+        className="cursor-pointer min-h-5"
+        onClick={() => !isEditing && setEditingCell(cellKey)}
+      >
+        {isEditing ? (
+          editControl
+        ) : display ? (
+          display
+        ) : (
+          <span className="text-slate">—</span>
+        )}
+      </div>
+    );
+  };
+
+  const toggleCell = (active: boolean | undefined, onToggle: () => void) => (
+    <div className="cursor-pointer text-center" onClick={onToggle}>
+      {active ? "✕" : ""}
+    </div>
+  );
+
+  const columns = useMemo(
+    () => [
+      columnHelper.display({
+        id: "remove",
+        header: "",
+        cell: ({ row }) => {
+          const { observation, speciesIndex } = row.original;
+          return (
+            <button
+              type="button"
+              onClick={() => removeSpeciesRow(observation, speciesIndex)}
+              className="text-slate hover:text-rust transition-colors"
+              aria-label="Fjern art"
+            >
+              <Trash2 size={14} />
+            </button>
+          );
+        },
+      }),
+      columnHelper.display({
+        id: "speciesName",
+        header: "Artsnavn",
+        cell: ({ row }) => {
+          const { observation, species, speciesIndex, rowId } = row.original;
+          return editableCell(
+            `${rowId}-speciesName`,
+            species.species.PrefferedPopularname ??
+              species.species.ValidScientificName,
+            <Input
+              autoFocus
+              defaultValue={
+                species.species.PrefferedPopularname ??
+                species.species.ValidScientificName ??
+                ""
+              }
+              onBlur={(e) => {
+                setSpeciesField(observation, speciesIndex, "species", {
+                  ...species.species,
+                  PrefferedPopularname: e.target.value,
+                });
+                setEditingCell(null);
+              }}
+            />,
+          );
+        },
+      }),
+      columnHelper.display({
+        id: "locationName",
+        header: "Lokalitetsnavn",
+        cell: ({ row }) => {
+          const { observation, rowId } = row.original;
+          return editableCell(
+            `${rowId}-locationName`,
+            observation.locationName,
+            <Input
+              autoFocus
+              defaultValue={observation.locationName || ""}
+              onBlur={(e) => {
+                setObservationField(observation, "locationName", e.target.value);
+                setEditingCell(null);
+              }}
+            />,
+          );
+        },
+      }),
+      columnHelper.display({
+        id: "uncertaintyRadius",
+        header: "Nøyaktighet",
+        cell: ({ row }) => {
+          const { observation, rowId } = row.original;
+          return editableCell(
+            `${rowId}-uncertaintyRadius`,
+            observation.uncertaintyRadius
+              ? `${observation.uncertaintyRadius} m`
+              : "",
+            <Input
+              autoFocus
+              type="number"
+              defaultValue={observation.uncertaintyRadius ?? ""}
+              onBlur={(e) => {
+                const parsed = Number.parseInt(e.target.value, 10);
+                if (!Number.isNaN(parsed)) {
+                  setObservationField(observation, "uncertaintyRadius", parsed);
+                }
+                setEditingCell(null);
+              }}
+            />,
+          );
+        },
+      }),
+      columnHelper.display({
+        id: "count",
+        header: "Antall",
+        cell: ({ row }) => {
+          const { observation, species, speciesIndex, rowId } = row.original;
+          return editableCell(
+            `${rowId}-count`,
+            species.count,
+            <Input
+              autoFocus
+              type="number"
+              min="1"
+              defaultValue={species.count ?? ""}
+              onBlur={(e) => {
+                const parsed = Number.parseInt(e.target.value, 10);
+                if (!Number.isNaN(parsed) && parsed >= 1) {
+                  setSpeciesField(observation, speciesIndex, "count", parsed);
+                }
+                setEditingCell(null);
+              }}
+            />,
+          );
+        },
+      }),
+      columnHelper.display({
+        id: "unit",
+        header: "Enhet",
+        cell: ({ row }) => {
+          const { observation, species, speciesIndex, rowId } = row.original;
+          const taxonGroup = species.species.TaxonGroup || "";
+          return editableCell(
+            `${rowId}-unit`,
+            species.unit,
+            <Combobox
+              value={species.unit || ""}
+              onChange={(v) => {
+                setSpeciesField(observation, speciesIndex, "unit", v);
+                setEditingCell(null);
+              }}
+              options={
+                getUnitOptionsForTaxonGroup(taxonGroup) as ComboboxOption[]
+              }
+            />,
+          );
+        },
+      }),
+      columnHelper.display({
+        id: "gender",
+        header: "Kjønn",
+        cell: ({ row }) => {
+          const { observation, species, speciesIndex, rowId } = row.original;
+          const taxonGroup = species.species.TaxonGroup || "";
+          return editableCell(
+            `${rowId}-gender`,
+            species.gender,
+            <Combobox
+              value={species.gender || ""}
+              onChange={(v) => {
+                setSpeciesField(observation, speciesIndex, "gender", v);
+                setEditingCell(null);
+              }}
+              options={
+                getGenderOptionsForTaxonGroup(taxonGroup) as ComboboxOption[]
+              }
+            />,
+          );
+        },
+      }),
+      columnHelper.display({
+        id: "age",
+        header: "Alder",
+        cell: ({ row }) => {
+          const { observation, species, speciesIndex, rowId } = row.original;
+          const taxonGroup = species.species.TaxonGroup || "";
+          return editableCell(
+            `${rowId}-age`,
+            species.age,
+            <Combobox
+              value={species.age || ""}
+              onChange={(v) => {
+                setSpeciesField(observation, speciesIndex, "age", v);
+                setEditingCell(null);
+              }}
+              options={
+                getAgeOptionsForTaxonGroup(taxonGroup) as ComboboxOption[]
+              }
+            />,
+          );
+        },
+      }),
+      columnHelper.display({
+        id: "method",
+        header: "Metode",
+        cell: ({ row }) => {
+          const { observation, species, speciesIndex, rowId } = row.original;
+          const taxonGroup = species.species.TaxonGroup || "";
+          return editableCell(
+            `${rowId}-method`,
+            species.method,
+            <Combobox
+              value={species.method || ""}
+              onChange={(v) => {
+                setSpeciesField(observation, speciesIndex, "method", v);
+                setEditingCell(null);
+              }}
+              options={
+                getMethodOptionsForTaxonGroup(taxonGroup) as ComboboxOption[]
+              }
+            />,
+          );
+        },
+      }),
+      columnHelper.display({
+        id: "activity",
+        header: "Aktivitet",
+        cell: ({ row }) => {
+          const { observation, species, speciesIndex, rowId } = row.original;
+          const taxonGroup = species.species.TaxonGroup || "";
+          return editableCell(
+            `${rowId}-activity`,
+            species.activity,
+            <Combobox
+              value={species.activity || ""}
+              onChange={(v) => {
+                setSpeciesField(observation, speciesIndex, "activity", v);
+                setEditingCell(null);
+              }}
+              options={
+                getActivityOptionsForTaxonGroup(taxonGroup) as ComboboxOption[]
+              }
+            />,
+          );
+        },
+      }),
+      columnHelper.display({
+        id: "startDateDate",
+        header: "Fra dato",
+        cell: ({ row }) => {
+          const { observation, rowId } = row.original;
+          return editableCell(
+            `${rowId}-startDateDate`,
+            formatDate(observation.startDate),
+            <DatePicker
+              value={dayjs(observation.startDate)}
+              onChange={(v) => {
+                if (!v) return;
+                const base = dayjs(observation.startDate);
+                setObservationField(
+                  observation,
+                  "startDate",
+                  base.year(v.year()).month(v.month()).date(v.date()).toISOString(),
+                );
+                setEditingCell(null);
+              }}
+            />,
+          );
+        },
+      }),
+      columnHelper.display({
+        id: "startDateTime",
+        header: "Fra klokkeslett",
+        cell: ({ row }) => {
+          const { observation, rowId } = row.original;
+          return editableCell(
+            `${rowId}-startDateTime`,
+            formatTime(observation.startDate),
+            <TimePicker
+              value={dayjs(observation.startDate)}
+              onChange={(hour, minute) => {
+                setObservationField(
+                  observation,
+                  "startDate",
+                  dayjs(observation.startDate)
+                    .hour(hour)
+                    .minute(minute)
+                    .second(0)
+                    .toISOString(),
+                );
+                setEditingCell(null);
+              }}
+            />,
+          );
+        },
+      }),
+      columnHelper.display({
+        id: "endDateDate",
+        header: "Til dato",
+        cell: ({ row }) => {
+          const { observation, rowId } = row.original;
+          return editableCell(
+            `${rowId}-endDateDate`,
+            formatDate(observation.endDate),
+            <DatePicker
+              value={observation.endDate ? dayjs(observation.endDate) : null}
+              onClear={() => {
+                setObservationField(observation, "endDate", undefined);
+                setEditingCell(null);
+              }}
+              onChange={(v) => {
+                if (!v) return;
+                const base = observation.endDate
+                  ? dayjs(observation.endDate)
+                  : dayjs(observation.startDate);
+                setObservationField(
+                  observation,
+                  "endDate",
+                  base.year(v.year()).month(v.month()).date(v.date()).toISOString(),
+                );
+                setEditingCell(null);
+              }}
+            />,
+          );
+        },
+      }),
+      columnHelper.display({
+        id: "endDateTime",
+        header: "Til klokkeslett",
+        cell: ({ row }) => {
+          const { observation, rowId } = row.original;
+          return editableCell(
+            `${rowId}-endDateTime`,
+            formatTime(observation.endDate),
+            <TimePicker
+              value={observation.endDate ? dayjs(observation.endDate) : null}
+              onChange={(hour, minute) => {
+                const base = observation.endDate
+                  ? dayjs(observation.endDate)
+                  : dayjs(observation.startDate);
+                setObservationField(
+                  observation,
+                  "endDate",
+                  base.hour(hour).minute(minute).second(0).toISOString(),
+                );
+                setEditingCell(null);
+              }}
+            />,
+          );
+        },
+      }),
+      columnHelper.display({
+        id: "speciesComment",
+        header: "Kommentar",
+        cell: ({ row }) => {
+          const { observation, species, speciesIndex, rowId } = row.original;
+          return editableCell(
+            `${rowId}-speciesComment`,
+            species.comment,
+            <Textarea
+              autoFocus
+              rows={2}
+              defaultValue={species.comment || ""}
+              onBlur={(e) => {
+                setSpeciesField(observation, speciesIndex, "comment", e.target.value);
+                setEditingCell(null);
+              }}
+            />,
+          );
+        },
+      }),
+      columnHelper.display({
+        id: "privateComment",
+        header: "Privat kommentar",
+        cell: ({ row }) => {
+          const { observation, species, speciesIndex, rowId } = row.original;
+          return editableCell(
+            `${rowId}-privateComment`,
+            species.privateComment,
+            <Textarea
+              autoFocus
+              rows={2}
+              defaultValue={species.privateComment || ""}
+              onBlur={(e) => {
+                setSpeciesField(
+                  observation,
+                  speciesIndex,
+                  "privateComment",
+                  e.target.value,
+                );
+                setEditingCell(null);
+              }}
+            />,
+          );
+        },
+      }),
+      columnHelper.display({
+        id: "observerName",
+        header: "Medobservatør",
+        cell: ({ row }) => {
+          const { observation, rowId } = row.original;
+          return editableCell(
+            `${rowId}-observerName`,
+            observation.observerName,
+            <Input
+              autoFocus
+              defaultValue={observation.observerName || ""}
+              onBlur={(e) => {
+                setObservationField(observation, "observerName", e.target.value);
+                setEditingCell(null);
+              }}
+            />,
+          );
+        },
+      }),
+      columnHelper.display({
+        id: "project",
+        header: "Prosjekt",
+        cell: ({ row }) => {
+          const { observation, rowId } = row.original;
+          return editableCell(
+            `${rowId}-project`,
+            observation.project,
+            <Input
+              autoFocus
+              defaultValue={observation.project || ""}
+              onBlur={(e) => {
+                setObservationField(observation, "project", e.target.value);
+                setEditingCell(null);
+              }}
+            />,
+          );
+        },
+      }),
+      columnHelper.display({
+        id: "notRediscovered",
+        header: "Ikke gjenfunnet",
+        cell: ({ row }) => {
+          const { observation, species, speciesIndex } = row.original;
+          return toggleCell(species.notRediscovered, () =>
+            setSpeciesField(
+              observation,
+              speciesIndex,
+              "notRediscovered",
+              !species.notRediscovered,
+            ),
+          );
+        },
+      }),
+      columnHelper.display({
+        id: "notFound",
+        header: "Ikke funnet",
+        cell: ({ row }) => {
+          const { observation, species, speciesIndex } = row.original;
+          return toggleCell(species.notFound, () =>
+            setSpeciesField(
+              observation,
+              speciesIndex,
+              "notFound",
+              !species.notFound,
+            ),
+          );
+        },
+      }),
+      columnHelper.display({
+        id: "secondHand",
+        header: "Andrehånds",
+        cell: ({ row }) => {
+          const { observation, species, speciesIndex } = row.original;
+          return toggleCell(species.secondHand, () =>
+            setSpeciesField(
+              observation,
+              speciesIndex,
+              "secondHand",
+              !species.secondHand,
+            ),
+          );
+        },
+      }),
+      columnHelper.display({
+        id: "uncertainIdentification",
+        header: "Usikker artsbestemming",
+        cell: ({ row }) => {
+          const { observation, species, speciesIndex } = row.original;
+          return toggleCell(species.uncertainIdentification, () =>
+            setSpeciesField(
+              observation,
+              speciesIndex,
+              "uncertainIdentification",
+              !species.uncertainIdentification,
+            ),
+          );
+        },
+      }),
+      columnHelper.display({
+        id: "hide",
+        header: "Skjul",
+        cell: ({ row }) => {
+          const { observation, species, speciesIndex } = row.original;
+          return toggleCell(species.hide, () =>
+            setSpeciesField(observation, speciesIndex, "hide", !species.hide),
+          );
+        },
+      }),
+    ],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [editingCell],
+  );
+
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getRowId: (row) => row.rowId,
+  });
+
+  return (
+    <div className="overflow-x-auto border-2 border-moss/40 rounded-md">
+      <table className="border-collapse w-full">
+        <thead>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map((header) => (
+                <th key={header.id} className={headerClass}>
+                  {flexRender(header.column.columnDef.header, header.getContext())}
+                </th>
+              ))}
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {table.getRowModel().rows.map((row) => {
+            const { isNewGroup, groupParity } = row.original;
+            return (
+              <tr
+                key={row.id}
+                className={twMerge(
+                  groupParity ? "bg-moss/5 dark:bg-moss/10" : "",
+                  isNewGroup ? "border-t-2 border-moss/40" : "",
+                )}
+              >
+                {row.getVisibleCells().map((cell) => (
+                  <td key={cell.id} className={cellClass}>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </td>
+                ))}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default ObservationsTable;

--- a/src/react-app/components/ObservationsTable.tsx
+++ b/src/react-app/components/ObservationsTable.tsx
@@ -52,8 +52,15 @@ const headerClass =
 
 const formatDate = (value?: string) =>
   value && dayjs(value).isValid() ? dayjs(value).format("DD.MM.YYYY") : "";
-const formatTime = (value?: string) =>
-  value && dayjs(value).isValid() ? dayjs(value).format("HH:mm") : "";
+const formatTime = (value?: string) => {
+  if (!value) return "";
+  const parsed = dayjs(value);
+  if (!parsed.isValid()) return "";
+  // 00:00 means no time was ever set on this observation — show blank
+  // rather than a misleading midnight timestamp.
+  if (parsed.hour() === 0 && parsed.minute() === 0) return "";
+  return parsed.format("HH:mm");
+};
 
 const columnHelper = createColumnHelper<FlatRow>();
 

--- a/src/react-app/components/ObservationsTable.tsx
+++ b/src/react-app/components/ObservationsTable.tsx
@@ -6,7 +6,14 @@ import {
   useReactTable,
 } from "@tanstack/react-table";
 import dayjs from "dayjs";
-import { ChevronLeft, ChevronRight, MapPinned, Trash2 } from "lucide-react";
+import {
+  Check,
+  ChevronLeft,
+  ChevronRight,
+  MapPinned,
+  Pencil,
+  Trash2,
+} from "lucide-react";
 import { Observation, Species } from "../types/observation.ts";
 import { useObservations } from "../context/ObservationsContext.tsx";
 import { Input } from "./ui/input.tsx";
@@ -22,10 +29,11 @@ import { getMethodOptionsForTaxonGroup } from "../lib/methodOptions.ts";
 import { getActivityOptionsForTaxonGroup } from "../lib/activityOptions.ts";
 import { twMerge } from "tailwind-merge";
 
-const OBSERVATIONS_PER_PAGE = 20;
+const ROWS_PER_PAGE = 20;
 
 interface ObservationsTableProps {
   observations: Observation[];
+  onEdit: (id: string) => void;
 }
 
 interface FlatRow {
@@ -70,7 +78,10 @@ const AutoFocusTextarea = (
   return <Textarea ref={ref} variant="ghost" {...props} />;
 };
 
-const ObservationsTable = ({ observations }: ObservationsTableProps) => {
+const ObservationsTable = ({
+  observations,
+  onEdit,
+}: ObservationsTableProps) => {
   const { updateObservation, deleteObservation } = useObservations();
   const [editingCell, setEditingCell] = useState<string | null>(null);
 
@@ -79,6 +90,7 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
     field: K,
     value: Observation[K],
   ) => {
+    if (observation[field] === value) return;
     updateObservation({ ...observation, [field]: value });
   };
 
@@ -88,6 +100,8 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
     field: K,
     value: Species[K],
   ) => {
+    const current = observation.species[speciesIndex];
+    if (current[field] === value) return;
     const nextSpecies = observation.species.map((s, i) =>
       i === speciesIndex ? { ...s, [field]: value } : s,
     );
@@ -133,29 +147,14 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
     [observations],
   );
 
-  const pageCount = Math.max(
-    1,
-    Math.ceil(sortedObservations.length / OBSERVATIONS_PER_PAGE),
-  );
-  const clampedPage = Math.min(page, pageCount - 1);
-
-  useEffect(() => {
-    if (page !== clampedPage) setPage(clampedPage);
-  }, [page, clampedPage]);
-
-  const pageObservations = useMemo(
-    () =>
-      sortedObservations.slice(
-        clampedPage * OBSERVATIONS_PER_PAGE,
-        (clampedPage + 1) * OBSERVATIONS_PER_PAGE,
-      ),
-    [sortedObservations, clampedPage],
-  );
-
-  const data = useMemo<FlatRow[]>(() => {
+  // Flatten to species-rows first, then paginate by row count directly
+  // (rather than by observation count), so page size reflects what's
+  // actually rendered — while keeping each observation's species rows
+  // together on one page.
+  const allRows = useMemo<FlatRow[]>(() => {
     let groupCount = 0;
     let lastObservationId: string | null = null;
-    return pageObservations.flatMap((observation) =>
+    return sortedObservations.flatMap((observation) =>
       observation.species.map((species, speciesIndex) => {
         const isNewGroup = observation.id !== lastObservationId;
         if (isNewGroup) groupCount++;
@@ -170,7 +169,35 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
         };
       }),
     );
-  }, [pageObservations]);
+  }, [sortedObservations]);
+
+  const pages = useMemo(() => {
+    const result: FlatRow[][] = [];
+    let current: FlatRow[] = [];
+    for (const row of allRows) {
+      if (row.isNewGroup && current.length >= ROWS_PER_PAGE) {
+        result.push(current);
+        current = [];
+      }
+      current.push(row);
+    }
+    if (current.length > 0) result.push(current);
+    return result.length > 0 ? result : [[]];
+  }, [allRows]);
+
+  const pageCount = pages.length;
+  const clampedPage = Math.min(page, pageCount - 1);
+
+  useEffect(() => {
+    if (page !== clampedPage) setPage(clampedPage);
+  }, [page, clampedPage]);
+
+  const data = pages[clampedPage];
+
+  const totalRows = allRows.length;
+  const rowsBeforePage = pages
+    .slice(0, clampedPage)
+    .reduce((sum, p) => sum + p.length, 0);
 
   /** Text-style cell: shows plain text, and the very first click both enters edit mode and focuses the input (no second click needed). */
   const textCell = (
@@ -226,29 +253,50 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
     <button
       type="button"
       onClick={onToggle}
-      className="w-full h-full text-center px-2 py-1.5 hover:bg-sand/60 dark:hover:bg-forest/60 transition-colors"
+      className="w-full h-full flex items-center justify-center px-2 py-1.5 hover:bg-sand/60 dark:hover:bg-forest/60 transition-colors"
+      role="checkbox"
+      aria-checked={!!active}
     >
-      {active ? "✕" : ""}
+      <span
+        className={twMerge(
+          "h-4 w-4 rounded-sm border-2 flex items-center justify-center",
+          active
+            ? "bg-moss border-moss text-white"
+            : "border-slate-border dark:border-slate bg-white dark:bg-bark",
+        )}
+      >
+        {active && <Check size={12} strokeWidth={3} />}
+      </span>
     </button>
   );
 
   const columns = useMemo(
     () => [
       columnHelper.display({
-        id: "remove",
+        id: "actions",
         header: "",
-        size: 44,
+        size: 72,
         cell: ({ row }) => {
           const { observation, speciesIndex } = row.original;
           return (
-            <button
-              type="button"
-              onClick={() => removeSpeciesRow(observation, speciesIndex)}
-              className="w-full h-full flex items-center justify-center px-2 py-1.5 text-slate hover:text-rust transition-colors"
-              aria-label="Fjern art"
-            >
-              <Trash2 size={14} />
-            </button>
+            <div className="w-full h-full flex items-center justify-center gap-1">
+              <button
+                type="button"
+                onClick={() => onEdit(observation.id)}
+                className="p-1 text-slate hover:text-moss transition-colors"
+                aria-label="Rediger observasjon"
+              >
+                <Pencil size={14} />
+              </button>
+              <button
+                type="button"
+                onClick={() => removeSpeciesRow(observation, speciesIndex)}
+                className="p-1 text-slate hover:text-rust transition-colors"
+                aria-label="Fjern art"
+              >
+                <Trash2 size={14} />
+              </button>
+            </div>
           );
         },
       }),
@@ -269,10 +317,18 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
                 ""
               }
               onBlur={(e) => {
-                setSpeciesField(observation, speciesIndex, "species", {
-                  ...species.species,
-                  PrefferedPopularname: e.target.value,
-                });
+                const nextName = e.target.value;
+                if (
+                  nextName !==
+                  (species.species.PrefferedPopularname ??
+                    species.species.ValidScientificName ??
+                    "")
+                ) {
+                  setSpeciesField(observation, speciesIndex, "species", {
+                    ...species.species,
+                    PrefferedPopularname: nextName,
+                  });
+                }
                 setEditingCell(null);
               }}
               onKeyDown={(e) => {
@@ -844,7 +900,7 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
   });
 
   return (
-    <div className="border-2 border-moss/40 rounded-md overflow-hidden">
+    <div className="border-2 border-moss/40 rounded-sm overflow-hidden">
       <div className="overflow-x-auto">
         <table className="border-collapse table-fixed">
           <colgroup>
@@ -895,12 +951,8 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
       {pageCount > 1 && (
         <div className="flex items-center justify-between gap-md px-md py-sm border-t-2 border-moss/40 bg-sand dark:bg-forest">
           <span className="text-xs text-slate">
-            Observasjon {clampedPage * OBSERVATIONS_PER_PAGE + 1}–
-            {Math.min(
-              (clampedPage + 1) * OBSERVATIONS_PER_PAGE,
-              sortedObservations.length,
-            )}{" "}
-            av {sortedObservations.length}
+            Observasjon {rowsBeforePage + 1}–{rowsBeforePage + data.length} av{" "}
+            {totalRows}
           </span>
           <div className="flex items-center gap-2">
             <Button

--- a/src/react-app/components/ObservationsTable.tsx
+++ b/src/react-app/components/ObservationsTable.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useMemo, useState } from "react";
+import { ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import {
   createColumnHelper,
   flexRender,
@@ -35,7 +35,7 @@ interface FlatRow {
 }
 
 const cellClass =
-  "px-2 py-1.5 text-sm text-bark dark:text-sand whitespace-nowrap align-middle";
+  "p-0 text-sm text-bark dark:text-sand whitespace-nowrap align-middle";
 const headerClass =
   "px-2 py-2 text-left text-xs font-semibold text-bark dark:text-sand whitespace-nowrap sticky top-0 bg-sand dark:bg-forest z-10 border-b-2 border-moss";
 
@@ -45,6 +45,29 @@ const formatTime = (value?: string) =>
   value && dayjs(value).isValid() ? dayjs(value).format("HH:mm") : "";
 
 const columnHelper = createColumnHelper<FlatRow>();
+
+/** Text/number input that auto-focuses and selects its content the moment it's mounted, so the first click into edit mode is ready to type over. */
+const AutoFocusInput = (
+  props: React.InputHTMLAttributes<HTMLInputElement>,
+) => {
+  const ref = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    ref.current?.focus();
+    ref.current?.select();
+  }, []);
+  return <Input ref={ref} variant="ghost" {...props} />;
+};
+
+const AutoFocusTextarea = (
+  props: React.TextareaHTMLAttributes<HTMLTextAreaElement>,
+) => {
+  const ref = useRef<HTMLTextAreaElement>(null);
+  useEffect(() => {
+    ref.current?.focus();
+    ref.current?.select();
+  }, []);
+  return <Textarea ref={ref} variant="ghost" {...props} />;
+};
 
 const ObservationsTable = ({ observations }: ObservationsTableProps) => {
   const { updateObservation, deleteObservation } = useObservations();
@@ -117,32 +140,64 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
     );
   }, [observations]);
 
-  const editableCell = (
+  /** Text-style cell: shows plain text, and the very first click both enters edit mode and focuses the input (no second click needed). */
+  const textCell = (
     cellKey: string,
     display: ReactNode,
     editControl: ReactNode,
   ) => {
     const isEditing = editingCell === cellKey;
+    if (isEditing) {
+      return editControl;
+    }
     return (
-      <div
-        className="cursor-pointer min-h-5"
-        onClick={() => !isEditing && setEditingCell(cellKey)}
+      <button
+        type="button"
+        onClick={() => setEditingCell(cellKey)}
+        className="w-full h-full text-left px-2 py-1.5 hover:bg-sand/60 dark:hover:bg-forest/60 transition-colors"
       >
-        {isEditing ? (
-          editControl
-        ) : display ? (
-          display
-        ) : (
-          <span className="text-slate">—</span>
-        )}
-      </div>
+        {display || <span className="text-slate">—</span>}
+      </button>
+    );
+  };
+
+  /** Dropdown/picker-style cell: the first click both enters edit mode and opens the popover immediately. */
+  const pickerCell = (
+    cellKey: string,
+    display: ReactNode,
+    renderControl: (opts: {
+      defaultOpen: boolean;
+      onOpenChange: (open: boolean) => void;
+    }) => ReactNode,
+  ) => {
+    const isEditing = editingCell === cellKey;
+    if (isEditing) {
+      return renderControl({
+        defaultOpen: true,
+        onOpenChange: (open) => {
+          if (!open) setEditingCell(null);
+        },
+      });
+    }
+    return (
+      <button
+        type="button"
+        onClick={() => setEditingCell(cellKey)}
+        className="w-full h-full text-left px-2 py-1.5 hover:bg-sand/60 dark:hover:bg-forest/60 transition-colors"
+      >
+        {display || <span className="text-slate">—</span>}
+      </button>
     );
   };
 
   const toggleCell = (active: boolean | undefined, onToggle: () => void) => (
-    <div className="cursor-pointer text-center" onClick={onToggle}>
+    <button
+      type="button"
+      onClick={onToggle}
+      className="w-full h-full text-center px-2 py-1.5 hover:bg-sand/60 dark:hover:bg-forest/60 transition-colors"
+    >
       {active ? "✕" : ""}
-    </div>
+    </button>
   );
 
   const columns = useMemo(
@@ -156,7 +211,7 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
             <button
               type="button"
               onClick={() => removeSpeciesRow(observation, speciesIndex)}
-              className="text-slate hover:text-rust transition-colors"
+              className="w-full h-full flex items-center justify-center px-2 py-1.5 text-slate hover:text-rust transition-colors"
               aria-label="Fjern art"
             >
               <Trash2 size={14} />
@@ -169,12 +224,11 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
         header: "Artsnavn",
         cell: ({ row }) => {
           const { observation, species, speciesIndex, rowId } = row.original;
-          return editableCell(
+          return textCell(
             `${rowId}-speciesName`,
             species.species.PrefferedPopularname ??
               species.species.ValidScientificName,
-            <Input
-              autoFocus
+            <AutoFocusInput
               defaultValue={
                 species.species.PrefferedPopularname ??
                 species.species.ValidScientificName ??
@@ -187,6 +241,10 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
                 });
                 setEditingCell(null);
               }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") e.currentTarget.blur();
+                if (e.key === "Escape") setEditingCell(null);
+              }}
             />,
           );
         },
@@ -196,15 +254,18 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
         header: "Lokalitetsnavn",
         cell: ({ row }) => {
           const { observation, rowId } = row.original;
-          return editableCell(
+          return textCell(
             `${rowId}-locationName`,
             observation.locationName,
-            <Input
-              autoFocus
+            <AutoFocusInput
               defaultValue={observation.locationName || ""}
               onBlur={(e) => {
                 setObservationField(observation, "locationName", e.target.value);
                 setEditingCell(null);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") e.currentTarget.blur();
+                if (e.key === "Escape") setEditingCell(null);
               }}
             />,
           );
@@ -215,13 +276,12 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
         header: "Nøyaktighet",
         cell: ({ row }) => {
           const { observation, rowId } = row.original;
-          return editableCell(
+          return textCell(
             `${rowId}-uncertaintyRadius`,
             observation.uncertaintyRadius
               ? `${observation.uncertaintyRadius} m`
               : "",
-            <Input
-              autoFocus
+            <AutoFocusInput
               type="number"
               defaultValue={observation.uncertaintyRadius ?? ""}
               onBlur={(e) => {
@@ -230,6 +290,10 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
                   setObservationField(observation, "uncertaintyRadius", parsed);
                 }
                 setEditingCell(null);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") e.currentTarget.blur();
+                if (e.key === "Escape") setEditingCell(null);
               }}
             />,
           );
@@ -240,11 +304,10 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
         header: "Antall",
         cell: ({ row }) => {
           const { observation, species, speciesIndex, rowId } = row.original;
-          return editableCell(
+          return textCell(
             `${rowId}-count`,
             species.count,
-            <Input
-              autoFocus
+            <AutoFocusInput
               type="number"
               min="1"
               defaultValue={species.count ?? ""}
@@ -254,6 +317,10 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
                   setSpeciesField(observation, speciesIndex, "count", parsed);
                 }
                 setEditingCell(null);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") e.currentTarget.blur();
+                if (e.key === "Escape") setEditingCell(null);
               }}
             />,
           );
@@ -265,20 +332,17 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
         cell: ({ row }) => {
           const { observation, species, speciesIndex, rowId } = row.original;
           const taxonGroup = species.species.TaxonGroup || "";
-          return editableCell(
-            `${rowId}-unit`,
-            species.unit,
+          const cellKey = `${rowId}-unit`;
+          return pickerCell(cellKey, species.unit, ({ defaultOpen, onOpenChange }) => (
             <Combobox
+              variant="ghost"
+              defaultOpen={defaultOpen}
+              onOpenChange={onOpenChange}
               value={species.unit || ""}
-              onChange={(v) => {
-                setSpeciesField(observation, speciesIndex, "unit", v);
-                setEditingCell(null);
-              }}
-              options={
-                getUnitOptionsForTaxonGroup(taxonGroup) as ComboboxOption[]
-              }
-            />,
-          );
+              onChange={(v) => setSpeciesField(observation, speciesIndex, "unit", v)}
+              options={getUnitOptionsForTaxonGroup(taxonGroup) as ComboboxOption[]}
+            />
+          ));
         },
       }),
       columnHelper.display({
@@ -287,20 +351,19 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
         cell: ({ row }) => {
           const { observation, species, speciesIndex, rowId } = row.original;
           const taxonGroup = species.species.TaxonGroup || "";
-          return editableCell(
-            `${rowId}-gender`,
-            species.gender,
+          const cellKey = `${rowId}-gender`;
+          return pickerCell(cellKey, species.gender, ({ defaultOpen, onOpenChange }) => (
             <Combobox
+              variant="ghost"
+              defaultOpen={defaultOpen}
+              onOpenChange={onOpenChange}
               value={species.gender || ""}
-              onChange={(v) => {
-                setSpeciesField(observation, speciesIndex, "gender", v);
-                setEditingCell(null);
-              }}
+              onChange={(v) => setSpeciesField(observation, speciesIndex, "gender", v)}
               options={
                 getGenderOptionsForTaxonGroup(taxonGroup) as ComboboxOption[]
               }
-            />,
-          );
+            />
+          ));
         },
       }),
       columnHelper.display({
@@ -309,20 +372,17 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
         cell: ({ row }) => {
           const { observation, species, speciesIndex, rowId } = row.original;
           const taxonGroup = species.species.TaxonGroup || "";
-          return editableCell(
-            `${rowId}-age`,
-            species.age,
+          const cellKey = `${rowId}-age`;
+          return pickerCell(cellKey, species.age, ({ defaultOpen, onOpenChange }) => (
             <Combobox
+              variant="ghost"
+              defaultOpen={defaultOpen}
+              onOpenChange={onOpenChange}
               value={species.age || ""}
-              onChange={(v) => {
-                setSpeciesField(observation, speciesIndex, "age", v);
-                setEditingCell(null);
-              }}
-              options={
-                getAgeOptionsForTaxonGroup(taxonGroup) as ComboboxOption[]
-              }
-            />,
-          );
+              onChange={(v) => setSpeciesField(observation, speciesIndex, "age", v)}
+              options={getAgeOptionsForTaxonGroup(taxonGroup) as ComboboxOption[]}
+            />
+          ));
         },
       }),
       columnHelper.display({
@@ -331,20 +391,19 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
         cell: ({ row }) => {
           const { observation, species, speciesIndex, rowId } = row.original;
           const taxonGroup = species.species.TaxonGroup || "";
-          return editableCell(
-            `${rowId}-method`,
-            species.method,
+          const cellKey = `${rowId}-method`;
+          return pickerCell(cellKey, species.method, ({ defaultOpen, onOpenChange }) => (
             <Combobox
+              variant="ghost"
+              defaultOpen={defaultOpen}
+              onOpenChange={onOpenChange}
               value={species.method || ""}
-              onChange={(v) => {
-                setSpeciesField(observation, speciesIndex, "method", v);
-                setEditingCell(null);
-              }}
+              onChange={(v) => setSpeciesField(observation, speciesIndex, "method", v)}
               options={
                 getMethodOptionsForTaxonGroup(taxonGroup) as ComboboxOption[]
               }
-            />,
-          );
+            />
+          ));
         },
       }),
       columnHelper.display({
@@ -353,20 +412,19 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
         cell: ({ row }) => {
           const { observation, species, speciesIndex, rowId } = row.original;
           const taxonGroup = species.species.TaxonGroup || "";
-          return editableCell(
-            `${rowId}-activity`,
-            species.activity,
+          const cellKey = `${rowId}-activity`;
+          return pickerCell(cellKey, species.activity, ({ defaultOpen, onOpenChange }) => (
             <Combobox
+              variant="ghost"
+              defaultOpen={defaultOpen}
+              onOpenChange={onOpenChange}
               value={species.activity || ""}
-              onChange={(v) => {
-                setSpeciesField(observation, speciesIndex, "activity", v);
-                setEditingCell(null);
-              }}
+              onChange={(v) => setSpeciesField(observation, speciesIndex, "activity", v)}
               options={
                 getActivityOptionsForTaxonGroup(taxonGroup) as ComboboxOption[]
               }
-            />,
-          );
+            />
+          ));
         },
       }),
       columnHelper.display({
@@ -374,22 +432,27 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
         header: "Fra dato",
         cell: ({ row }) => {
           const { observation, rowId } = row.original;
-          return editableCell(
-            `${rowId}-startDateDate`,
+          const cellKey = `${rowId}-startDateDate`;
+          return pickerCell(
+            cellKey,
             formatDate(observation.startDate),
-            <DatePicker
-              value={dayjs(observation.startDate)}
-              onChange={(v) => {
-                if (!v) return;
-                const base = dayjs(observation.startDate);
-                setObservationField(
-                  observation,
-                  "startDate",
-                  base.year(v.year()).month(v.month()).date(v.date()).toISOString(),
-                );
-                setEditingCell(null);
-              }}
-            />,
+            ({ defaultOpen, onOpenChange }) => (
+              <DatePicker
+                variant="ghost"
+                defaultOpen={defaultOpen}
+                onOpenChange={onOpenChange}
+                value={dayjs(observation.startDate)}
+                onChange={(v) => {
+                  if (!v) return;
+                  const base = dayjs(observation.startDate);
+                  setObservationField(
+                    observation,
+                    "startDate",
+                    base.year(v.year()).month(v.month()).date(v.date()).toISOString(),
+                  );
+                }}
+              />
+            ),
           );
         },
       }),
@@ -398,10 +461,12 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
         header: "Fra klokkeslett",
         cell: ({ row }) => {
           const { observation, rowId } = row.original;
-          return editableCell(
+          return textCell(
             `${rowId}-startDateTime`,
             formatTime(observation.startDate),
             <TimePicker
+              variant="ghost"
+              autoOpen
               value={dayjs(observation.startDate)}
               onChange={(hour, minute) => {
                 setObservationField(
@@ -424,28 +489,33 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
         header: "Til dato",
         cell: ({ row }) => {
           const { observation, rowId } = row.original;
-          return editableCell(
-            `${rowId}-endDateDate`,
+          const cellKey = `${rowId}-endDateDate`;
+          return pickerCell(
+            cellKey,
             formatDate(observation.endDate),
-            <DatePicker
-              value={observation.endDate ? dayjs(observation.endDate) : null}
-              onClear={() => {
-                setObservationField(observation, "endDate", undefined);
-                setEditingCell(null);
-              }}
-              onChange={(v) => {
-                if (!v) return;
-                const base = observation.endDate
-                  ? dayjs(observation.endDate)
-                  : dayjs(observation.startDate);
-                setObservationField(
-                  observation,
-                  "endDate",
-                  base.year(v.year()).month(v.month()).date(v.date()).toISOString(),
-                );
-                setEditingCell(null);
-              }}
-            />,
+            ({ defaultOpen, onOpenChange }) => (
+              <DatePicker
+                variant="ghost"
+                defaultOpen={defaultOpen}
+                onOpenChange={onOpenChange}
+                value={observation.endDate ? dayjs(observation.endDate) : null}
+                onClear={() => {
+                  setObservationField(observation, "endDate", undefined);
+                  setEditingCell(null);
+                }}
+                onChange={(v) => {
+                  if (!v) return;
+                  const base = observation.endDate
+                    ? dayjs(observation.endDate)
+                    : dayjs(observation.startDate);
+                  setObservationField(
+                    observation,
+                    "endDate",
+                    base.year(v.year()).month(v.month()).date(v.date()).toISOString(),
+                  );
+                }}
+              />
+            ),
           );
         },
       }),
@@ -454,10 +524,12 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
         header: "Til klokkeslett",
         cell: ({ row }) => {
           const { observation, rowId } = row.original;
-          return editableCell(
+          return textCell(
             `${rowId}-endDateTime`,
             formatTime(observation.endDate),
             <TimePicker
+              variant="ghost"
+              autoOpen
               value={observation.endDate ? dayjs(observation.endDate) : null}
               onChange={(hour, minute) => {
                 const base = observation.endDate
@@ -479,16 +551,18 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
         header: "Kommentar",
         cell: ({ row }) => {
           const { observation, species, speciesIndex, rowId } = row.original;
-          return editableCell(
+          return textCell(
             `${rowId}-speciesComment`,
             species.comment,
-            <Textarea
-              autoFocus
+            <AutoFocusTextarea
               rows={2}
               defaultValue={species.comment || ""}
               onBlur={(e) => {
                 setSpeciesField(observation, speciesIndex, "comment", e.target.value);
                 setEditingCell(null);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Escape") setEditingCell(null);
               }}
             />,
           );
@@ -499,11 +573,10 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
         header: "Privat kommentar",
         cell: ({ row }) => {
           const { observation, species, speciesIndex, rowId } = row.original;
-          return editableCell(
+          return textCell(
             `${rowId}-privateComment`,
             species.privateComment,
-            <Textarea
-              autoFocus
+            <AutoFocusTextarea
               rows={2}
               defaultValue={species.privateComment || ""}
               onBlur={(e) => {
@@ -515,6 +588,9 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
                 );
                 setEditingCell(null);
               }}
+              onKeyDown={(e) => {
+                if (e.key === "Escape") setEditingCell(null);
+              }}
             />,
           );
         },
@@ -524,15 +600,18 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
         header: "Medobservatør",
         cell: ({ row }) => {
           const { observation, rowId } = row.original;
-          return editableCell(
+          return textCell(
             `${rowId}-observerName`,
             observation.observerName,
-            <Input
-              autoFocus
+            <AutoFocusInput
               defaultValue={observation.observerName || ""}
               onBlur={(e) => {
                 setObservationField(observation, "observerName", e.target.value);
                 setEditingCell(null);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") e.currentTarget.blur();
+                if (e.key === "Escape") setEditingCell(null);
               }}
             />,
           );
@@ -543,15 +622,18 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
         header: "Prosjekt",
         cell: ({ row }) => {
           const { observation, rowId } = row.original;
-          return editableCell(
+          return textCell(
             `${rowId}-project`,
             observation.project,
-            <Input
-              autoFocus
+            <AutoFocusInput
               defaultValue={observation.project || ""}
               onBlur={(e) => {
                 setObservationField(observation, "project", e.target.value);
                 setEditingCell(null);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") e.currentTarget.blur();
+                if (e.key === "Escape") setEditingCell(null);
               }}
             />,
           );

--- a/src/react-app/components/ObservationsTable.tsx
+++ b/src/react-app/components/ObservationsTable.tsx
@@ -6,7 +6,7 @@ import {
   useReactTable,
 } from "@tanstack/react-table";
 import dayjs from "dayjs";
-import { ChevronLeft, ChevronRight, Trash2 } from "lucide-react";
+import { ChevronLeft, ChevronRight, MapPinned, Trash2 } from "lucide-react";
 import { Observation, Species } from "../types/observation.ts";
 import { useObservations } from "../context/ObservationsContext.tsx";
 import { Input } from "./ui/input.tsx";
@@ -291,7 +291,17 @@ const ObservationsTable = ({ observations }: ObservationsTableProps) => {
           const { observation, rowId } = row.original;
           return textCell(
             `${rowId}-locationName`,
-            observation.locationName,
+            observation.locationName && (
+              <span className="flex items-center gap-1.5 truncate">
+                {observation.locationId && (
+                  <MapPinned
+                    size={14}
+                    className="shrink-0 text-violet-600 dark:text-violet-400"
+                  />
+                )}
+                <span className="truncate">{observation.locationName}</span>
+              </span>
+            ),
             <AutoFocusInput
               defaultValue={observation.locationName || ""}
               onBlur={(e) => {

--- a/src/react-app/components/ObservationsTable.tsx
+++ b/src/react-app/components/ObservationsTable.tsx
@@ -213,7 +213,7 @@ const ObservationsTable = ({
       <button
         type="button"
         onClick={() => setEditingCell(cellKey)}
-        className="w-full h-full text-left px-2 py-1.5 hover:bg-sand/60 dark:hover:bg-forest/60 transition-colors"
+        className="w-full h-full text-left px-2 py-1.5 hover:bg-moss/15 dark:hover:bg-moss/25 transition-colors"
       >
         {display || <span className="text-slate">—</span>}
       </button>
@@ -242,7 +242,7 @@ const ObservationsTable = ({
       <button
         type="button"
         onClick={() => setEditingCell(cellKey)}
-        className="w-full h-full text-left px-2 py-1.5 hover:bg-sand/60 dark:hover:bg-forest/60 transition-colors"
+        className="w-full h-full text-left px-2 py-1.5 hover:bg-moss/15 dark:hover:bg-moss/25 transition-colors"
       >
         {display || <span className="text-slate">—</span>}
       </button>
@@ -253,7 +253,7 @@ const ObservationsTable = ({
     <button
       type="button"
       onClick={onToggle}
-      className="w-full h-full flex items-center justify-center px-2 py-1.5 hover:bg-sand/60 dark:hover:bg-forest/60 transition-colors"
+      className="w-full h-full flex items-center justify-center px-2 py-1.5 hover:bg-moss/15 dark:hover:bg-moss/25 transition-colors"
       role="checkbox"
       aria-checked={!!active}
     >

--- a/src/react-app/components/ui/Modal.tsx
+++ b/src/react-app/components/ui/Modal.tsx
@@ -87,7 +87,7 @@ export function Modal({
 
   return (
     <div
-      className="fixed inset-0 z-[1000] flex items-center justify-center bg-black/50 backdrop-blur-sm p-4"
+      className="fixed inset-0 z-[1200] flex items-center justify-center bg-black/50 backdrop-blur-sm p-4"
       onClick={handleBackdropClick}
     >
       <div

--- a/src/react-app/components/ui/combobox.tsx
+++ b/src/react-app/components/ui/combobox.tsx
@@ -107,7 +107,7 @@ const Combobox = ({
         <PopoverPrimitive.Content
           align="start"
           sideOffset={4}
-          className="z-[1100] w-[var(--radix-popover-trigger-width)] rounded-md border-2 border-slate-border dark:border-slate bg-white dark:bg-bark shadow-custom-lg overflow-hidden"
+          className="z-[1100] w-[max(var(--radix-popover-trigger-width),14rem)] rounded-md border-2 border-slate-border dark:border-slate bg-white dark:bg-bark shadow-custom-lg overflow-hidden"
         >
           <CommandPrimitive shouldFilter={false} className="flex flex-col">
             <CommandPrimitive.Input

--- a/src/react-app/components/ui/combobox.tsx
+++ b/src/react-app/components/ui/combobox.tsx
@@ -20,6 +20,12 @@ interface ComboboxProps {
   emptyText?: string;
   customEntryLabel?: (input: string) => string;
   className?: string;
+  /** Render without the boxy trigger chrome, for use inside dense contexts like table cells. */
+  variant?: "default" | "ghost";
+  /** Open the popover as soon as this mounts, e.g. for click-to-edit table cells. */
+  defaultOpen?: boolean;
+  /** Fires whenever the popover opens/closes, so a caller can e.g. exit edit mode on close. */
+  onOpenChange?: (open: boolean) => void;
 }
 
 const Combobox = ({
@@ -32,9 +38,18 @@ const Combobox = ({
   emptyText = "Ingen treff",
   customEntryLabel = (input) => `Bruk "${input}"`,
   className,
+  variant = "default",
+  defaultOpen = false,
+  onOpenChange,
 }: ComboboxProps) => {
-  const [open, setOpen] = React.useState(false);
+  const [open, setOpen] = React.useState(defaultOpen);
   const [search, setSearch] = React.useState("");
+
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    if (!next) setSearch("");
+    onOpenChange?.(next);
+  };
 
   const selectedOption = options.find((opt) => opt.value === value);
   const displayLabel = selectedOption?.label ?? value;
@@ -60,16 +75,11 @@ const Combobox = ({
     onChange(next);
     setSearch("");
     setOpen(false);
+    onOpenChange?.(false);
   };
 
   return (
-    <PopoverPrimitive.Root
-      open={open}
-      onOpenChange={(next) => {
-        setOpen(next);
-        if (!next) setSearch("");
-      }}
-    >
+    <PopoverPrimitive.Root open={open} onOpenChange={handleOpenChange}>
       <PopoverPrimitive.Trigger asChild>
         <button
           id={id}
@@ -77,7 +87,9 @@ const Combobox = ({
           role="combobox"
           aria-expanded={open}
           className={cn(
-            "flex h-10 w-full items-center justify-between rounded-md border-2 border-slate-border bg-white dark:bg-bark dark:border-slate text-bark dark:text-sand px-3 py-2 text-sm ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-moss focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+            variant === "ghost"
+              ? "flex h-full w-full items-center justify-between gap-1 rounded-none bg-transparent px-2 py-1.5 text-sm text-bark dark:text-sand outline-none focus-visible:outline-none focus-visible:ring-0"
+              : "flex h-10 w-full items-center justify-between rounded-md border-2 border-slate-border bg-white dark:bg-bark dark:border-slate text-bark dark:text-sand px-3 py-2 text-sm ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-moss focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
             className,
           )}
         >
@@ -86,7 +98,9 @@ const Combobox = ({
           >
             {displayLabel || placeholder}
           </span>
-          <ChevronDown size={16} className="shrink-0 opacity-50 ml-2" />
+          {variant !== "ghost" && (
+            <ChevronDown size={16} className="shrink-0 opacity-50 ml-2" />
+          )}
         </button>
       </PopoverPrimitive.Trigger>
       <PopoverPrimitive.Portal>

--- a/src/react-app/components/ui/combobox.tsx
+++ b/src/react-app/components/ui/combobox.tsx
@@ -33,7 +33,7 @@ const Combobox = ({
   value,
   onChange,
   options,
-  placeholder = "Velg...",
+  placeholder = "",
   searchPlaceholder = "Søk...",
   emptyText = "Ingen treff",
   customEntryLabel = (input) => `Bruk "${input}"`,

--- a/src/react-app/components/ui/combobox.tsx
+++ b/src/react-app/components/ui/combobox.tsx
@@ -33,7 +33,7 @@ const Combobox = ({
   value,
   onChange,
   options,
-  placeholder = "",
+  placeholder = "Velg...",
   searchPlaceholder = "Søk...",
   emptyText = "Ingen treff",
   customEntryLabel = (input) => `Bruk "${input}"`,

--- a/src/react-app/components/ui/date-picker.tsx
+++ b/src/react-app/components/ui/date-picker.tsx
@@ -12,6 +12,12 @@ interface DatePickerProps {
   onClear?: () => void;
   placeholder?: string;
   className?: string;
+  /** Render without the boxy trigger chrome, for use inside dense contexts like table cells. */
+  variant?: "default" | "ghost";
+  /** Open the popover as soon as this mounts, e.g. for click-to-edit table cells. */
+  defaultOpen?: boolean;
+  /** Fires whenever the popover opens/closes, so a caller can e.g. exit edit mode on close. */
+  onOpenChange?: (open: boolean) => void;
 }
 
 const DatePicker = ({
@@ -21,22 +27,34 @@ const DatePicker = ({
   onClear,
   placeholder = "Velg dato",
   className,
+  variant = "default",
+  defaultOpen = false,
+  onOpenChange,
 }: DatePickerProps) => {
-  const [open, setOpen] = React.useState(false);
+  const [open, setOpen] = React.useState(defaultOpen);
   const selected = value && value.isValid() ? value.toDate() : undefined;
 
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    onOpenChange?.(next);
+  };
+
   return (
-    <PopoverPrimitive.Root open={open} onOpenChange={setOpen}>
+    <PopoverPrimitive.Root open={open} onOpenChange={handleOpenChange}>
       <PopoverPrimitive.Trigger asChild>
         <button
           id={id}
           type="button"
           className={cn(
-            "flex h-10 w-full items-center gap-2 rounded-md border-2 border-slate-border bg-white dark:bg-bark dark:border-slate text-bark dark:text-sand px-3 py-2 text-sm ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-moss focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+            variant === "ghost"
+              ? "flex h-full w-full items-center gap-1.5 rounded-none bg-transparent px-2 py-1.5 text-sm text-bark dark:text-sand outline-none focus-visible:outline-none focus-visible:ring-0"
+              : "flex h-10 w-full items-center gap-2 rounded-md border-2 border-slate-border bg-white dark:bg-bark dark:border-slate text-bark dark:text-sand px-3 py-2 text-sm ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-moss focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
             className,
           )}
         >
-          <CalendarIcon size={16} className="shrink-0 opacity-50" />
+          {variant !== "ghost" && (
+            <CalendarIcon size={16} className="shrink-0 opacity-50" />
+          )}
           <span className={cn("truncate flex-1 text-left", !selected && "text-slate")}>
             {selected ? dayjs(selected).format("DD.MM.YYYY") : placeholder}
           </span>
@@ -71,6 +89,7 @@ const DatePicker = ({
                   .date(date.getDate()),
               );
               setOpen(false);
+              onOpenChange?.(false);
             }}
           />
         </PopoverPrimitive.Content>

--- a/src/react-app/components/ui/input.tsx
+++ b/src/react-app/components/ui/input.tsx
@@ -1,15 +1,20 @@
 import * as React from "react";
 import { cn } from "../../lib/utils";
 
-type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+type InputProps = React.InputHTMLAttributes<HTMLInputElement> & {
+  /** Render without the boxy chrome, for use inside dense contexts like table cells. */
+  variant?: "default" | "ghost";
+};
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, ...props }, ref) => {
+  ({ className, type, variant = "default", ...props }, ref) => {
     return (
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border-2 border-slate-border bg-white dark:bg-bark dark:border-slate text-bark dark:text-sand px-3 py-2 text-sm ring-offset-white file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-slate focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-moss focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 max-w-full",
+          variant === "ghost"
+            ? "flex h-full w-full rounded-none bg-transparent px-2 py-1.5 text-sm text-bark dark:text-sand ring-0 outline-none placeholder:text-slate focus-visible:outline-none focus-visible:ring-0 disabled:cursor-not-allowed disabled:opacity-50 max-w-full"
+            : "flex h-10 w-full rounded-md border-2 border-slate-border bg-white dark:bg-bark dark:border-slate text-bark dark:text-sand px-3 py-2 text-sm ring-offset-white file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-slate focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-moss focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 max-w-full",
           className,
         )}
         ref={ref}

--- a/src/react-app/components/ui/textarea.tsx
+++ b/src/react-app/components/ui/textarea.tsx
@@ -1,14 +1,19 @@
 import * as React from "react";
 import { cn } from "../../lib/utils";
 
-type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
+  /** Render without the boxy chrome, for use inside dense contexts like table cells. */
+  variant?: "default" | "ghost";
+};
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ className, ...props }, ref) => {
+  ({ className, variant = "default", ...props }, ref) => {
     return (
       <textarea
         className={cn(
-          "flex min-h-[80px] w-full rounded-md border-2 border-slate-border bg-white dark:bg-bark dark:border-slate text-bark dark:text-sand px-3 py-2 text-sm ring-offset-white placeholder:text-slate focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-moss focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          variant === "ghost"
+            ? "flex w-full rounded-none bg-transparent px-2 py-1.5 text-sm text-bark dark:text-sand outline-none placeholder:text-slate focus-visible:outline-none focus-visible:ring-0 disabled:cursor-not-allowed disabled:opacity-50"
+            : "flex min-h-[80px] w-full rounded-md border-2 border-slate-border bg-white dark:bg-bark dark:border-slate text-bark dark:text-sand px-3 py-2 text-sm ring-offset-white placeholder:text-slate focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-moss focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className,
         )}
         ref={ref}

--- a/src/react-app/components/ui/time-picker.tsx
+++ b/src/react-app/components/ui/time-picker.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import { Dayjs } from "dayjs";
 import { Clock } from "lucide-react";
 import { Input } from "./input";
@@ -8,28 +9,55 @@ interface TimePickerProps {
   value?: Dayjs | null;
   onChange: (hour: number, minute: number) => void;
   className?: string;
+  /** Render without the boxy input chrome, for use inside dense contexts like table cells. */
+  variant?: "default" | "ghost";
+  /** Focus (and try to open the native time picker) as soon as this mounts. */
+  autoOpen?: boolean;
 }
 
-const TimePicker = ({ id, value, onChange, className }: TimePickerProps) => {
-  const timeValue =
-    value && value.isValid() ? value.format("HH:mm") : "";
+const TimePicker = ({
+  id,
+  value,
+  onChange,
+  className,
+  variant = "default",
+  autoOpen = false,
+}: TimePickerProps) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const timeValue = value && value.isValid() ? value.format("HH:mm") : "";
+
+  useEffect(() => {
+    if (!autoOpen) return;
+    const input = inputRef.current;
+    if (!input) return;
+    input.focus();
+    input.showPicker?.();
+  }, [autoOpen]);
 
   return (
     <div className={cn("relative", className)}>
-      <Clock
-        size={16}
-        className="absolute left-3 top-1/2 -translate-y-1/2 text-slate pointer-events-none"
-      />
+      {variant !== "ghost" && (
+        <Clock
+          size={16}
+          className="absolute left-3 top-1/2 -translate-y-1/2 text-slate pointer-events-none"
+        />
+      )}
       <Input
+        ref={inputRef}
         id={id}
         type="time"
+        variant={variant}
         value={timeValue}
         onChange={(e) => {
           const [hour, minute] = e.target.value.split(":").map(Number);
           if (Number.isNaN(hour) || Number.isNaN(minute)) return;
           onChange(hour, minute);
         }}
-        className="pl-8"
+        className={
+          variant === "ghost"
+            ? "hover:bg-sand/60 dark:hover:bg-forest/60"
+            : "pl-8"
+        }
       />
     </div>
   );

--- a/src/react-app/components/ui/time-picker.tsx
+++ b/src/react-app/components/ui/time-picker.tsx
@@ -28,10 +28,10 @@ const TimePicker = ({
 
   useEffect(() => {
     if (!autoOpen) return;
-    const input = inputRef.current;
-    if (!input) return;
-    input.focus();
-    input.showPicker?.();
+    // Only focus — showPicker() requires an active user gesture and throws
+    // when called from an effect (which runs a tick after the click that
+    // triggered the mount).
+    inputRef.current?.focus();
   }, [autoOpen]);
 
   return (

--- a/src/react-app/queries/useObservation.ts
+++ b/src/react-app/queries/useObservation.ts
@@ -39,10 +39,9 @@ export function useCreateObservation() {
         queryKey: ["observations"],
       });
 
-      const optimisticId = `optimistic-${crypto.randomUUID()}`;
       const optimisticObservation: Observation = {
         ...input,
-        id: optimisticId,
+        id: `optimistic-${crypto.randomUUID()}`,
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
         species: input.species.map((s) => ({
@@ -57,24 +56,15 @@ export function useCreateObservation() {
         (old) => [optimisticObservation, ...(old ?? [])],
       );
 
-      return { previous, optimisticId };
-    },
-    onSuccess: (created, _input, context) => {
-      // Swap the optimistic placeholder for the real row returned by the
-      // server, without a refetch — avoids a visible blink from replacing
-      // already-correct data a moment later.
-      qc.setQueriesData<Observation[]>(
-        { queryKey: ["observations"] },
-        (old) =>
-          old?.map((obs) =>
-            obs.id === context?.optimisticId ? created : obs,
-          ) ?? old,
-      );
+      return { previous };
     },
     onError: (_err, _input, context) => {
       context?.previous.forEach(([queryKey, data]) => {
         qc.setQueryData(queryKey, data);
       });
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: ["observations"] });
     },
   });
 }
@@ -98,19 +88,13 @@ export function useUpdateObservation() {
 
       return { previous };
     },
-    onSuccess: (updated) => {
-      // Reconcile with the server's copy (e.g. updatedAt) without a
-      // refetch, so a successful save doesn't cause a visible re-render blink.
-      qc.setQueriesData<Observation[]>(
-        { queryKey: ["observations"] },
-        (old) =>
-          old?.map((obs) => (obs.id === updated.id ? updated : obs)) ?? old,
-      );
-    },
     onError: (_err, _input, context) => {
       context?.previous.forEach(([queryKey, data]) => {
         qc.setQueryData(queryKey, data);
       });
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: ["observations"] });
     },
   });
 }
@@ -137,6 +121,9 @@ export function useDeleteObservation() {
       context?.previous.forEach(([queryKey, data]) => {
         qc.setQueryData(queryKey, data);
       });
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: ["observations"] });
     },
   });
 }

--- a/src/react-app/queries/useObservation.ts
+++ b/src/react-app/queries/useObservation.ts
@@ -39,9 +39,10 @@ export function useCreateObservation() {
         queryKey: ["observations"],
       });
 
+      const optimisticId = `optimistic-${crypto.randomUUID()}`;
       const optimisticObservation: Observation = {
         ...input,
-        id: `optimistic-${crypto.randomUUID()}`,
+        id: optimisticId,
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
         species: input.species.map((s) => ({
@@ -56,15 +57,24 @@ export function useCreateObservation() {
         (old) => [optimisticObservation, ...(old ?? [])],
       );
 
-      return { previous };
+      return { previous, optimisticId };
+    },
+    onSuccess: (created, _input, context) => {
+      // Swap the optimistic placeholder for the real row returned by the
+      // server, without a refetch — avoids a visible blink from replacing
+      // already-correct data a moment later.
+      qc.setQueriesData<Observation[]>(
+        { queryKey: ["observations"] },
+        (old) =>
+          old?.map((obs) =>
+            obs.id === context?.optimisticId ? created : obs,
+          ) ?? old,
+      );
     },
     onError: (_err, _input, context) => {
       context?.previous.forEach(([queryKey, data]) => {
         qc.setQueryData(queryKey, data);
       });
-    },
-    onSettled: () => {
-      qc.invalidateQueries({ queryKey: ["observations"] });
     },
   });
 }
@@ -88,13 +98,19 @@ export function useUpdateObservation() {
 
       return { previous };
     },
+    onSuccess: (updated) => {
+      // Reconcile with the server's copy (e.g. updatedAt) without a
+      // refetch, so a successful save doesn't cause a visible re-render blink.
+      qc.setQueriesData<Observation[]>(
+        { queryKey: ["observations"] },
+        (old) =>
+          old?.map((obs) => (obs.id === updated.id ? updated : obs)) ?? old,
+      );
+    },
     onError: (_err, _input, context) => {
       context?.previous.forEach(([queryKey, data]) => {
         qc.setQueryData(queryKey, data);
       });
-    },
-    onSettled: () => {
-      qc.invalidateQueries({ queryKey: ["observations"] });
     },
   });
 }
@@ -121,9 +137,6 @@ export function useDeleteObservation() {
       context?.previous.forEach(([queryKey, data]) => {
         qc.setQueryData(queryKey, data);
       });
-    },
-    onSettled: () => {
-      qc.invalidateQueries({ queryKey: ["observations"] });
     },
   });
 }

--- a/src/react-app/queries/useObservation.ts
+++ b/src/react-app/queries/useObservation.ts
@@ -1,4 +1,9 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  keepPreviousData,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { Observation } from "../types/observation.ts";
 import {
   createObservation,
@@ -15,6 +20,10 @@ export const useFetchObservations = (options?: { enabled?: boolean }) => {
     queryFn: () => fetchObservations(user?.id),
     queryKey: ["observations", user?.id],
     enabled: options?.enabled ?? true,
+    // Keep showing the last successful data (instead of clearing to
+    // undefined/loading) while a refetch is in flight, e.g. after an
+    // invalidation triggered by a mutation.
+    placeholderData: keepPreviousData,
   });
 };
 
@@ -24,7 +33,37 @@ export function useCreateObservation() {
 
   return useMutation({
     mutationFn: (input: CreateObservation) => createObservation(input, user),
-    onSuccess: () => {
+    onMutate: async (input) => {
+      await qc.cancelQueries({ queryKey: ["observations"] });
+      const previous = qc.getQueriesData<Observation[]>({
+        queryKey: ["observations"],
+      });
+
+      const optimisticObservation: Observation = {
+        ...input,
+        id: `optimistic-${crypto.randomUUID()}`,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        species: input.species.map((s) => ({
+          ...s,
+          id: `optimistic-${crypto.randomUUID()}`,
+          createdAt: new Date().toISOString(),
+        })),
+      };
+
+      qc.setQueriesData<Observation[]>(
+        { queryKey: ["observations"] },
+        (old) => [optimisticObservation, ...(old ?? [])],
+      );
+
+      return { previous };
+    },
+    onError: (_err, _input, context) => {
+      context?.previous.forEach(([queryKey, data]) => {
+        qc.setQueryData(queryKey, data);
+      });
+    },
+    onSettled: () => {
       qc.invalidateQueries({ queryKey: ["observations"] });
     },
   });
@@ -35,7 +74,26 @@ export function useUpdateObservation() {
 
   return useMutation({
     mutationFn: (input: Observation) => updateObservation(input),
-    onSuccess: () => {
+    onMutate: async (input) => {
+      await qc.cancelQueries({ queryKey: ["observations"] });
+      const previous = qc.getQueriesData<Observation[]>({
+        queryKey: ["observations"],
+      });
+
+      qc.setQueriesData<Observation[]>(
+        { queryKey: ["observations"] },
+        (old) =>
+          old?.map((obs) => (obs.id === input.id ? input : obs)) ?? old,
+      );
+
+      return { previous };
+    },
+    onError: (_err, _input, context) => {
+      context?.previous.forEach(([queryKey, data]) => {
+        qc.setQueryData(queryKey, data);
+      });
+    },
+    onSettled: () => {
       qc.invalidateQueries({ queryKey: ["observations"] });
     },
   });
@@ -46,7 +104,25 @@ export function useDeleteObservation() {
 
   return useMutation({
     mutationFn: (observationId: string) => deleteObservation(observationId),
-    onSuccess: () => {
+    onMutate: async (observationId) => {
+      await qc.cancelQueries({ queryKey: ["observations"] });
+      const previous = qc.getQueriesData<Observation[]>({
+        queryKey: ["observations"],
+      });
+
+      qc.setQueriesData<Observation[]>(
+        { queryKey: ["observations"] },
+        (old) => old?.filter((obs) => obs.id !== observationId) ?? old,
+      );
+
+      return { previous };
+    },
+    onError: (_err, _observationId, context) => {
+      context?.previous.forEach(([queryKey, data]) => {
+        qc.setQueryData(queryKey, data);
+      });
+    },
+    onSettled: () => {
       qc.invalidateQueries({ queryKey: ["observations"] });
     },
   });


### PR DESCRIPTION
Adds a spreadsheet-style view (built on @tanstack/react-table) as an
alternative to the existing card list on /observations, toggled via
a new list/table switcher. One row per species per observation,
columns matching the Excel export exactly. Cells are click-to-edit:
clicking swaps the display value for the matching control (Input,
Combobox, DatePicker/TimePicker, or a toggle for boolean flags) and
commits on blur/selection via the existing updateObservation flow.

Rows belonging to the same observation share a background band and a
group divider, since editing a shared field (locality, dates,
uncertainty, comment, observer, project) updates every sibling
species row in that observation. Each row has a delete action that
removes just that species, or the whole observation if it's the last
one.

Default sort is startDate descending (newest first); column-header
sorting is left for a follow-up.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>